### PR TITLE
Editor QoL and Index Backup Changes/Downloads

### DIFF
--- a/FFXIV_TexTools/Helpers/FlexibleMessageBox.cs
+++ b/FFXIV_TexTools/Helpers/FlexibleMessageBox.cs
@@ -826,6 +826,18 @@ namespace FFXIV_TexTools.Helpers
             /// <returns>The dialog result.</returns>
             public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton)
             {
+                if(owner == null)
+                {
+                    try
+                    {
+                        var mainWindow = MainWindow.GetMainWindow();
+                        owner = mainWindow.Win32Window;
+                    } catch
+                    {
+                        // No-Op.
+                    }
+                }
+
                 //Create a new instance of the FlexibleMessageBox form
                 var flexibleMessageBoxForm = new FlexibleMessageBoxForm();
                 flexibleMessageBoxForm.ShowInTaskbar = false;

--- a/FFXIV_TexTools/MainWindow.xaml
+++ b/FFXIV_TexTools/MainWindow.xaml
@@ -68,6 +68,7 @@
             </MenuItem>
             <MenuItem Header="{Binding Source={x:Static resx:UIStrings.Help}}">
                 <MenuItem x:Name="Menu_Backup" Header="{Binding Source={x:Static resx:UIStrings.Backup_Index_Files}}" Click="Menu_Backup_Click"/>
+                <MenuItem x:Name="Menu_WebBackups" Header="{Binding Source={x:Static resx:UIStrings.Download_Backups}}" Click="Menu_WebBackups_Click" />
                 <MenuItem x:Name="Menu_ProblemCheck" Header="{Binding Source={x:Static resx:UIStrings.Check_For_Problems}}" Click="Menu_ProblemCheck_Click"/>
                 <MenuItem x:Name="Menu_StartOver" Header="{Binding Source={x:Static resx:UIStrings.Start_Over}}" Click="Menu_StartOver_Click" />
                 <MenuItem x:Name="Menu_BugReport" Header="{Binding Source={x:Static resx:UIStrings.Report_Bug}}" Click="Menu_BugReport_Click"/>

--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using FFXIV_TexTools.Resources;
 using FFXIV_TexTools.ViewModels;
 using FFXIV_TexTools.Views;
 using FFXIV_TexTools.Views.Models;
+using FolderSelect;
 using MahApps.Metro;
 using MahApps.Metro.Controls.Dialogs;
 using SixLabors.ImageSharp;
@@ -28,10 +29,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
+using System.Windows.Interop;
 using System.Windows.Threading;
 using xivModdingFramework.Cache;
 using xivModdingFramework.General.Enums;
@@ -53,6 +57,7 @@ namespace FFXIV_TexTools
         private string _startupArgs;
         private static MainWindow _mainWindow;
         private FullModelView _fmv;
+        public readonly System.Windows.Forms.IWin32Window Win32Window;
 
 
         /// <summary>
@@ -125,6 +130,7 @@ namespace FFXIV_TexTools
         public MainWindow(string[] args)
         {
             _mainWindow = this;
+
             AutoUpdater.ApplicationExitEvent += AutoUpdater_ApplicationExitEvent;
 
             // Forcefully assign the correct working directory.  This helps keep the 
@@ -206,6 +212,9 @@ namespace FFXIV_TexTools
             else
             {
                 this.Show();
+
+                // Can set this now that we're open.
+                Win32Window = new WindowWrapper(new WindowInteropHelper(this).Handle);
 
 
                 var textureView = TextureTabItem.Content as TextureView;
@@ -1232,6 +1241,86 @@ namespace FFXIV_TexTools
             fmv.Owner = this;
 
             fmv.Show();
+        }
+
+
+        private void Menu_WebBackups_Click(object sender, RoutedEventArgs e)
+        {
+            DownloadIndexBackups();
+        }
+        private async Task DownloadIndexBackups()
+        {
+            var url = UIStrings.Index_Backups_Url;
+            if (url == "INVALID" || String.IsNullOrWhiteSpace(url))
+            {
+                FlexibleMessageBox.Show("Index backup download is not currently supported for your client language.", "Web Download Error", MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1);
+                return;
+            }
+
+            var result = FlexibleMessageBox.Show("This will download index backups from the internet. Proceed?", "Web Download Confirmation",MessageBoxButtons.OKCancel, MessageBoxIcon.Information, MessageBoxDefaultButton.Button2);
+
+            if (result != System.Windows.Forms.DialogResult.OK) return;
+
+            await LockUi("Downloading Backups");
+            try
+            {
+                await Task.Run(async () =>
+                {
+                    _lockProgress.Report("Downloading Indexes...");
+                    var localPath = Path.GetTempFileName();
+                    using (var client = new WebClient())
+                    {
+                        client.DownloadFile(url, localPath);
+                    }
+
+                    var tempDir = Path.GetTempPath();
+                    tempDir += "/index_backup";
+                    var tempDi = new DirectoryInfo(tempDir);
+                    foreach (FileInfo file in tempDi.GetFiles())
+                    {
+                        file.Delete();
+                    }
+
+
+                    Directory.CreateDirectory(tempDir);
+
+                    _lockProgress.Report("Unzipping new Indexes...");
+                    ZipFile.ExtractToDirectory(localPath, tempDir);
+
+                    _lockProgress.Report("Checking downloaded index version...");
+                    var versionRaw = File.ReadAllText(tempDir + "/ffxivgame.ver");
+                    
+                    Version version = new Version(versionRaw.Substring(0, versionRaw.LastIndexOf(".", StringComparison.Ordinal)));
+
+                    if (version != XivCache.GameInfo.GameVersion)
+                    {
+                        throw new Exception("Downloaded Index version does not match game version.");
+                    }
+
+                    _lockProgress.Report("Removing old Backups...");
+                    var backupDir = new DirectoryInfo(Settings.Default.Backup_Directory);
+                    foreach (FileInfo file in backupDir.GetFiles())
+                    {
+                        file.Delete();
+                    }
+
+                    _lockProgress.Report("Copying new indexes to backup directory...");
+                    ZipFile.ExtractToDirectory(localPath, Settings.Default.Backup_Directory);
+
+
+                    _lockProgress.Report("Job Done.");
+                });
+                FlexibleMessageBox.Show("Successfully downloaded fresh index backups.\nYou may now use [Start Over] to apply them, if desired.", "Backup Download Success", MessageBoxButtons.OK, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+            }
+            catch(Exception Ex)
+            {
+                FlexibleMessageBox.Show("Unable to download Index Backups.\n\n" + Ex.Message, "Web Download Error", MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1);
+
+            }
+            finally
+            {
+                await UnlockUi();
+            }
         }
     }
 }

--- a/FFXIV_TexTools/Resources/UIMessages.Designer.cs
+++ b/FFXIV_TexTools/Resources/UIMessages.Designer.cs
@@ -214,7 +214,7 @@ namespace FFXIV_TexTools.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This will create a backup of the commonly modified index files (0a, 01, 04, 06)
+        ///   Looks up a localized string similar to This will create a backup of all index files.
         ///
         ///
         ///Do you want to Backup Now?

--- a/FFXIV_TexTools/Resources/UIMessages.resx
+++ b/FFXIV_TexTools/Resources/UIMessages.resx
@@ -156,7 +156,7 @@ Please set your Index Backups directory in Options &gt; Customize and try again.
     <value>ColorSet BMP import is not supported.</value>
   </data>
   <data name="CreateBackupsMessage" xml:space="preserve">
-    <value>This will create a backup of the commonly modified index files (0a, 01, 04, 06)
+    <value>This will create a backup of all index files.
 
 
 Do you want to Backup Now?

--- a/FFXIV_TexTools/Resources/UIStrings.Designer.cs
+++ b/FFXIV_TexTools/Resources/UIStrings.Designer.cs
@@ -594,6 +594,15 @@ namespace FFXIV_TexTools.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Download Index Backups.
+        /// </summary>
+        public static string Download_Backups {
+            get {
+                return ResourceManager.GetString("Download_Backups", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit.
         /// </summary>
         public static string Edit {
@@ -1013,6 +1022,15 @@ namespace FFXIV_TexTools.Resources {
         public static string Included_Mods_in_Option {
             get {
                 return ResourceManager.GetString("Included_Mods_in_Option", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://textools.sfo2.digitaloceanspaces.com/Index_Backups.zip.
+        /// </summary>
+        public static string Index_Backups_Url {
+            get {
+                return ResourceManager.GetString("Index_Backups_Url", resourceCulture);
             }
         }
         

--- a/FFXIV_TexTools/Resources/UIStrings.ko.resx
+++ b/FFXIV_TexTools/Resources/UIStrings.ko.resx
@@ -398,6 +398,9 @@
   <data name="Included_Mods_in_Option" xml:space="preserve">
     <value>옵션을 포함한 모드</value>
   </data>
+  <data name="Index_Backups_Url" xml:space="preserve">
+    <value>NONE</value>
+  </data>
   <data name="Index_Locked" xml:space="preserve">
     <value>게임이 실행중에는 들여올수 없습니다.</value>
   </data>

--- a/FFXIV_TexTools/Resources/UIStrings.resx
+++ b/FFXIV_TexTools/Resources/UIStrings.resx
@@ -991,4 +991,10 @@ If you would like to enable this, first import a texture for the selected item.<
   <data name="Skin" xml:space="preserve">
     <value>Skin</value>
   </data>
+  <data name="Download_Backups" xml:space="preserve">
+    <value>Download Index Backups</value>
+  </data>
+  <data name="Index_Backups_Url" xml:space="preserve">
+    <value>https://textools.sfo2.digitaloceanspaces.com/Index_Backups.zip</value>
+  </data>
 </root>

--- a/FFXIV_TexTools/Resources/UIStrings.zh.resx
+++ b/FFXIV_TexTools/Resources/UIStrings.zh.resx
@@ -747,4 +747,7 @@
   <data name="Convert_To" xml:space="preserve">
     <value>转换到</value>
   </data>
+  <data name="Index_Backups_Url" xml:space="preserve">
+    <value>NONE</value>
+  </data>
 </root>

--- a/FFXIV_TexTools/ViewModels/ImportModelEditViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ImportModelEditViewModel.cs
@@ -754,6 +754,9 @@ namespace FFXIV_TexTools.ViewModels
             { "fv", XivStrings.Face },
             { "hv", XivStrings.Hair },
             { "ev", XivStrings.Earring },
+            { "nv", XivStrings.Neck },
+            { "wv", XivStrings.Wrists },
+            { "rv", XivStrings.Rings },
             { "nv", null },
         };
 
@@ -826,6 +829,26 @@ namespace FFXIV_TexTools.ViewModels
                 "atr_ev_a",
                 "atr_ev_b",
                 "atr_ev_c",
+            } },
+            { "nek", new List<string> () {
+                "atr_nv_a",
+                "atr_nv_b",
+                "atr_nv_c",
+            } },
+            { "wrs", new List<string> () {
+                "atr_wv_a",
+                "atr_wv_b",
+                "atr_wv_c",
+            } },
+            { "rir", new List<string> () {
+                "atr_rv_a",
+                "atr_rv_b",
+                "atr_rv_c",
+            } },
+            { "ril", new List<string> () {
+                "atr_rv_a",
+                "atr_rv_b",
+                "atr_rv_c",
             } },
             { "fac", new List<string> () {
                 "atr_hig",

--- a/FFXIV_TexTools/ViewModels/ImportModelEditViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ImportModelEditViewModel.cs
@@ -757,7 +757,6 @@ namespace FFXIV_TexTools.ViewModels
             { "nv", XivStrings.Neck },
             { "wv", XivStrings.Wrists },
             { "rv", XivStrings.Rings },
-            { "nv", null },
         };
 
 

--- a/FFXIV_TexTools/ViewModels/ImportModelEditViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ImportModelEditViewModel.cs
@@ -15,9 +15,11 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
+using xivModdingFramework.Cache;
 using xivModdingFramework.General.Enums;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.Items;
+using xivModdingFramework.Items.Enums;
 using xivModdingFramework.Items.Interfaces;
 using xivModdingFramework.Models.DataContainers;
 using xivModdingFramework.Models.FileTypes;
@@ -36,7 +38,7 @@ namespace FFXIV_TexTools.ViewModels
         private readonly Regex ImcAttributeRegex = new Regex("^atr_([a-z]{2})_([a-j])$");
 
         private readonly Regex DefaultSkinRegex = new Regex("\\/mt_c[0-9]{4}b0001_a\\.mtrl");
-        private readonly Regex ItemMaterialRegex = new Regex("\\/mt_c([0-9]{4})e[0-9]{4}_[a-z0-9]{3}_([a-z])\\.mtrl");
+        private readonly Regex ItemMaterialRegex = new Regex("\\/mt_c([0-9]{4})[e|a][0-9]{4}_[a-z0-9]{3}_([a-z])+\\.mtrl");
         private const string SkinMaterial = "/mt_c0101b0001_a.mtrl";
         private readonly KeyValuePair<string, string> DefaultTag = new KeyValuePair<string, string>("_!ADDNEW!_", "Add Attributes...");
         private readonly KeyValuePair<string, string> CustomTag = new KeyValuePair<string, string>("_!CUSTOM!_", "Custom");
@@ -47,6 +49,10 @@ namespace FFXIV_TexTools.ViewModels
         private readonly float NewModelSize;
         private const float MinAcceptableSize = 0.5f;
         private const float MaxAcceptableSize = 2f;
+
+        private HashSet<string> RootMaterials = new HashSet<string>();
+
+        private XivDependencyRoot _root;
 
         private TTMeshGroup GetGroup()
         {
@@ -75,6 +81,9 @@ namespace FFXIV_TexTools.ViewModels
             _newModel = newModel;
             _oldModel = oldModel;
 
+
+
+            // Get all the materials available.
 
             // Merge all the default skin materials together, since FFXIV auto-handles them anyways.
             foreach (var m in _newModel.MeshGroups)
@@ -142,14 +151,33 @@ namespace FFXIV_TexTools.ViewModels
 
             OldModelSize = Vector3.Distance(min, max);
 
+
+            AsyncInit();
+        }
+
+        private async Task AsyncInit()
+        {
+            // Get this model's root.
+            _root = await XivCache.GetFirstRoot(_oldModel.Source);
+
+            if (_root != null && _root.Info.PrimaryType != XivItemType.indoor && _root.Info.PrimaryType != XivItemType.outdoor)
+            {
+                // Get all the materials in this root, and add them to the selectable list.
+                
+                var materials = await _root.GetMaterialFiles();
+                foreach (var m in materials)
+                {
+                    var mName = Path.GetFileName(m);
+                    mName = "/" + mName;
+                    RootMaterials.Add(mName);
+                }
+
+                RootMaterials = RootMaterials.OrderBy(x => x).ToHashSet();
+            }
+
             UpdateModelSizeWarning();
-
-
             UpdateMaterialsList();
 
-
-
-            
             _view.MeshNumberBox.SelectionChanged += MeshNumberBox_SelectionChanged;
             _view.PartNumberBox.SelectionChanged += PartNumberBox_SelectionChanged;
             _view.MaterialSelectorBox.SelectionChanged += MaterialSelectorBox_SelectionChanged;
@@ -269,28 +297,48 @@ namespace FFXIV_TexTools.ViewModels
             if (!_view.MaterialsSource.Contains(SkinTag))
             {
                 _view.MaterialsSource.Add(SkinTag);
+
+                // Get our root materials, if we have any
+                foreach(var m in RootMaterials)
+                {
+                    AddMaterial(m);
+                }
             }
 
             // Add in any new item materials.
             foreach (var m in _newModel.MeshGroups)
             {
-                var result = ItemMaterialRegex.Match(m.Material);
-                if (result.Success)
-                {
-                    if (_view.MaterialsSource.Any(x => x.Key == m.Material)) continue;
-
-                    // We have a new item material here that we haven't added to the list yet.
-                    var raceId = result.Groups[1].Value;
-                    var partId = result.Groups[2].Value;
-                    var race = XivRaces.GetXivRace(raceId);
-                    _view.MaterialsSource.Add(new KeyValuePair<string, string>(m.Material, "Material " + partId.ToUpper() + " - " + XivRaces.GetDisplayName(race)));
-
-                }
+                AddMaterial(m.Material);
             }
 
             // Re-Add the custom tag.
             _view.MaterialsSource.Add(CustomTag);
         }
+
+        private void AddMaterial(string m)
+        {
+            if (_view.MaterialsSource.Any(x => x.Key == m)) return;
+
+            var result = ItemMaterialRegex.Match(m);
+            if (result.Success
+                // This check is a little janky, but it's to avoid reading cross-slot references as the same item.
+                // ... Not that this should ever really happen, but it's *technically* possible.
+                && (_root.Info.Slot == null || m.Contains(_root.Info.Slot)))
+            {
+                // We have a new item material here that we haven't added to the list yet.
+                var raceId = result.Groups[1].Value;
+                var partId = result.Groups[2].Value;
+                var race = XivRaces.GetXivRace(raceId);
+                _view.MaterialsSource.Add(new KeyValuePair<string, string>(m, "Material " + partId.ToUpper() + " - " + XivRaces.GetDisplayName(race)));
+            }
+            else
+            {
+                _view.MaterialsSource.Add(new KeyValuePair<string, string>(m, Path.GetFileNameWithoutExtension(m)));
+            }
+
+        }
+
+        private static Regex _getRaceRegex = new Regex("c([0-9]{4})");
 
         // Repopulates the list box showing what attributes are available to add.
         private void ResetAvailableAttributesList()
@@ -300,8 +348,58 @@ namespace FFXIV_TexTools.ViewModels
 
             _view.AllAttributesSource.Add(DefaultTag);
 
+            // Get all standard attributes for this root.
+            HashSet<string> atrList = new HashSet<string>();
+            if(_root != null)
+            {
+                if(_root.Info.Slot != null && AttributesBySlot.ContainsKey(_root.Info.Slot))
+                {
+                    var slotAttributes = AttributesBySlot[_root.Info.Slot];
+                    slotAttributes.ForEach(x => atrList.Add(x));
+                }
+
+                if(AttributesByType.ContainsKey(_root.Info.PrimaryType))
+                {
+                    AttributesByType[_root.Info.PrimaryType].ForEach(x => atrList.Add(x));
+                }
+
+                if (_root.Info.PrimaryType == XivItemType.human && (_root.Info.SecondaryType == XivItemType.hair || _root.Info.SecondaryType == XivItemType.face))
+                {
+                    // Hair & Face has some special attributes that are only available for Miqo'te.
+                    var match = _getRaceRegex.Match(_oldModel.Source);
+                    if(match.Success == true && 
+                        (match.Groups[1].Value.StartsWith("08")
+                        || match.Groups[1].Value.StartsWith("07")))
+                    {
+                        // This is a Miqote (PC/NPC) (M/F) Hair or Face model.
+                        atrList.Add("atr_top");
+
+                        if (_root.Info.SecondaryType == XivItemType.hair)
+                        {
+                            atrList.Add("atr_sta");
+                        }
+                    }
+
+                    // Au Ra F has some special handling for faces.
+                    if (match.Success == true && match.Groups[1].Value.StartsWith("14") && _root.Info.SecondaryType == XivItemType.face)
+                    {
+                        // This is a weird Au Ra F thing.
+                        atrList.Add("atr_hair");
+                    }
+
+                }
+            }
+
             var attributes = new List<KeyValuePair<string, string>>(_newModel.Attributes.Count);
             foreach (var a in _newModel.Attributes)
+            {
+                // Add any attributes in the model that we didn't already pick up.
+                if (!atrList.Contains(a)) {
+                    atrList.Add(a);
+                }
+            }
+
+            foreach(var a in atrList)
             {
                 var r = _view.AllAttributesSource.FirstOrDefault(x => x.Key == a);
                 if (r.Key == null)
@@ -311,7 +409,7 @@ namespace FFXIV_TexTools.ViewModels
             }
             
             // Sort the attributes by their nice name before adding them.
-            attributes = attributes.OrderBy(x => x.Value).ToList();
+            //attributes = attributes.OrderBy(x => x.Value).ToList();
             foreach(var kv in attributes)
             {
                 _view.AllAttributesSource.Add(kv);
@@ -596,7 +694,6 @@ namespace FFXIV_TexTools.ViewModels
         private static readonly Dictionary<string, string> NiceAttributeNames = new Dictionary<string, string>()
         {
 
-            { "atr_hair","Hair" },
             { "atr_kam", "Scalp" },
             { "atr_hig", "Facial Hair" },
             { "atr_mim", "Ear" },
@@ -605,7 +702,9 @@ namespace FFXIV_TexTools.ViewModels
 
             // Used in weapons
             { "atr_arrow", "Arrow" },
-            { "atr_ar0", "Quiver Arrow" },
+            { "atr_ar1", "Quiver Arrow 1" },
+            { "atr_ar2", "Quiver Arrow 2" },
+            { "atr_ar3", "Quiver Arrow 3" },
             { "atr_attach", "Gauss Barrel" },
 
             // Used in Body gear
@@ -635,15 +734,18 @@ namespace FFXIV_TexTools.ViewModels
             { "atr_tls", "Tail Races Only" },
 
             // Unknown/unverified
-            { "atr_top", "Body" },
-            { "atr_sta", null },
+            
+            { "atr_blt", "Belt" },
+            { "atr_top", "Miqo'te Ears" },
+            { "atr_sta", "Miqo'te Long Hair Unique" },
+            { "atr_hair","Au Ra F Face Unique" },
 
             // IMC Attributes are handled below in GetNiceAttributeName()
         };
 
         private static readonly Dictionary<string, string> NiceImcAttributeNames = new Dictionary<string, string>()
         {
-            { "bv", "Weapon" },
+            { "bv", "Other" },
             { "dv", XivStrings.Legs },
             { "mv", XivStrings.Head },
             { "gv", XivStrings.Hands},
@@ -651,8 +753,97 @@ namespace FFXIV_TexTools.ViewModels
             { "tv", XivStrings.Body },
             { "fv", XivStrings.Face },
             { "hv", XivStrings.Hair },
+            { "ev", XivStrings.Earring },
             { "nv", null },
         };
+
+
+
+        private static readonly Dictionary<XivItemType, List<string>> AttributesByType = new Dictionary<XivItemType, List<string>>()
+        {
+            { XivItemType.weapon, new List<string> () {
+                "atr_arrow",
+                "atr_ar1",
+                "atr_ar2",
+                "atr_ar3",
+                "atr_attach",
+                "atr_bv_a",
+                "atr_bv_b",
+                "atr_bv_c",
+            } },
+            { XivItemType.monster, new List<string> () {
+                "atr_bv_a",
+                "atr_bv_b",
+                "atr_bv_c",
+            } },
+            { XivItemType.demihuman, new List<string> () {
+                "atr_bv_a",
+                "atr_bv_b",
+                "atr_bv_c",
+            } }
+        };
+
+        private static readonly Dictionary<string, List<string>> AttributesBySlot = new Dictionary<string, List<string>>()
+        {
+            { "met", new List<string> () {
+                "atr_inr",
+                "atr_mv_a",
+                "atr_mv_b",
+                "atr_mv_c",
+            } },
+            { "top", new List<string> () {
+                "atr_hij",
+                "atr_nek",
+                "atr_ude",
+                "atr_tlh",
+                "atr_tls",
+                "atr_tv_a",
+                "atr_tv_b",
+                "atr_tv_c",
+            } },
+            { "glv", new List<string> () {
+                "atr_arm",
+                "atr_gv_a",
+                "atr_gv_b",
+                "atr_gv_c",
+            } },
+            { "dwn", new List<string> () {
+                "atr_hiz",
+                "atr_kod",
+                "atr_sne",
+                "atr_dv_a",
+                "atr_dv_b",
+                "atr_dv_c",
+            } },
+            { "sho", new List<string> () {
+                "atr_leg",
+                "atr_spd",
+                "atr_sv_a",
+                "atr_sv_b",
+                "atr_sv_c",
+            } },
+            { "ear", new List<string> () {
+                "atr_ev_a",
+                "atr_ev_b",
+                "atr_ev_c",
+            } },
+            { "fac", new List<string> () {
+                "atr_hig",
+                "atr_hrn",
+                "atr_kao",
+                "atr_mim",
+                "atr_fv_a",
+                "atr_fv_b",
+                "atr_fv_c",
+            } },
+            { "hir", new List<string> () {
+                "atr_kam",
+                "atr_hv_a",
+                "atr_hv_b",
+                "atr_hv_c",
+            } },
+        };
+
         /// <summary>
         /// The list of nice, human readable attribute names, keyed by their underlying FFXIV name.
         /// </summary>
@@ -661,12 +852,12 @@ namespace FFXIV_TexTools.ViewModels
         {
             // This is mostly a copy of the atr list, but sometimes the names change,
             // so it's listed as a separate dictionary.
-            { "shp_hair","Hair" },
             { "shp_kam", "Scalp" },
             { "shp_hig", "Facial Hair" },
             { "shp_mim", "Ear" },
             { "shp_hrn", "Horn" },
             { "shp_kao", "Face" },
+
 
             // Used in weapons
             { "shp_arrow", "Arrow" },
@@ -677,6 +868,7 @@ namespace FFXIV_TexTools.ViewModels
             { "shp_hij", "Wrist" },
             { "shp_ude", "Elbow" },
             { "shp_nek", "Neck" },
+            { "shp_blt", "Belt" },
 
             // Used in Leg gear
             { "shp_kod", "Waist" },
@@ -700,8 +892,9 @@ namespace FFXIV_TexTools.ViewModels
             { "shp_tls", "Tail Races Only" },
 
             // Unknown/unverified
-            { "shp_top", "Body" },
-            { "shp_sta", null },
+            { "shp_top", "Miqo'te Ears" },
+            { "shp_sta", "Miqo'te Hair Unique" },
+            { "shp_hair", "Au Ra F Face Unique" },
 
             // Face stuff.
             // Was it the smartest idea to do these by hand?  Probably not.

--- a/FFXIV_TexTools/ViewModels/ImportModelViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ImportModelViewModel.cs
@@ -25,7 +25,7 @@ namespace FFXIV_TexTools.ViewModels
 {
     public class ImportModelViewModel
     {
-        private const int ExpandedHeight = 640;
+        private const int ExpandedHeight = 680;
         private const double CloseDelay = 3000f;
 
         private ImportModelView _view;
@@ -181,6 +181,7 @@ namespace FFXIV_TexTools.ViewModels
             options.CloneUV2 = _view.CloneUV1Button.IsChecked == true ? true : false;
             options.ClearVAlpha = _view.ClearVAlphaButton.IsChecked == true ? true : false;
             options.ClearVColor = _view.ClearVColorButton.IsChecked == true ? true : false;
+            options.AutoScale = _view.AutoScaleButton.IsChecked == true ? true : false;
 
             // Asynchronously call ImportModel.
             Task.Run(async () =>

--- a/FFXIV_TexTools/ViewModels/MainViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/MainViewModel.cs
@@ -57,7 +57,6 @@ namespace FFXIV_TexTools.ViewModels
         private int _progressValue;
         private Visibility _progressBarVisible, _progressLabelVisible;
         private Index _index;
-        private System.Windows.Forms.IWin32Window _win32Window;
         private ProgressDialogController _progressController;
         public System.Timers.Timer CacheTimer = new System.Timers.Timer(3000);
 
@@ -66,7 +65,6 @@ namespace FFXIV_TexTools.ViewModels
         public MainViewModel(MainWindow mainWindow)
         {
             _mainWindow = mainWindow;
-            _win32Window = new WindowWrapper(new WindowInteropHelper(_mainWindow).Handle);
             // This is actually synchronous and can just be called immediately...
             SetDirectories(true);
 
@@ -164,7 +162,7 @@ namespace FFXIV_TexTools.ViewModels
 
                 if (modListContent.Length > 0)
                 {
-                    if (FlexibleMessageBox.Show(_win32Window, 
+                    if (FlexibleMessageBox.Show(_mainWindow.Win32Window, 
                             UIMessages.OldTexToolsFoundMessage, UIMessages.OldModListFoundTitle,
                             MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                     {
@@ -175,7 +173,7 @@ namespace FFXIV_TexTools.ViewModels
 
                         if (_index.IsIndexLocked(XivDataFile._0A_Exd))
                         {
-                            FlexibleMessageBox.Show(_win32Window, UIMessages.ModListIndexLockedErrorMessage,
+                            FlexibleMessageBox.Show(_mainWindow.Win32Window, UIMessages.ModListIndexLockedErrorMessage,
                                 UIMessages.ModListDisableFailedTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                             error = true;
                         }
@@ -188,7 +186,7 @@ namespace FFXIV_TexTools.ViewModels
                             catch (Exception ex)
                             {
                                 error = true;
-                                FlexibleMessageBox.Show(_win32Window, 
+                                FlexibleMessageBox.Show(_mainWindow.Win32Window, 
                                     string.Format(UIMessages.OldModListDisableFailedMessage, ex.Message),
                                     UIMessages.PreviousVersionErrorTitle, MessageBoxButtons.OK,
                                     MessageBoxIcon.Error);
@@ -466,7 +464,7 @@ namespace FFXIV_TexTools.ViewModels
             }
             else
             {
-                FlexibleMessageBox.Show(_win32Window, UIMessages.GameVersionErrorMessage,
+                FlexibleMessageBox.Show(_mainWindow.Win32Window, UIMessages.GameVersionErrorMessage,
                     string.Format(UIMessages.GameVersionErrorTitle, applicationVersion), MessageBoxButtons.OK,
                     MessageBoxIcon.Warning);
                 return;
@@ -493,7 +491,7 @@ namespace FFXIV_TexTools.ViewModels
 
             if (!Directory.Exists(backupDirectory.FullName))
             {
-                FlexibleMessageBox.Show(_win32Window, UIMessages.BackupsDirectoryErrorMessage, UIMessages.BackupFailedTitle,
+                FlexibleMessageBox.Show(_mainWindow.Win32Window, UIMessages.BackupsDirectoryErrorMessage, UIMessages.BackupFailedTitle,
                     MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
@@ -509,13 +507,13 @@ namespace FFXIV_TexTools.ViewModels
                 var indexFiles = new XivDataFile[]
                     { XivDataFile._0A_Exd, XivDataFile._04_Chara, XivDataFile._06_Ui, XivDataFile._01_Bgcommon };
 
-                if (FlexibleMessageBox.Show(_win32Window, backupMessage, UIMessages.CreateBackupTitle, MessageBoxButtons.YesNo,
+                if (FlexibleMessageBox.Show(_mainWindow.Win32Window, backupMessage, UIMessages.CreateBackupTitle, MessageBoxButtons.YesNo,
                         MessageBoxIcon.Warning) == DialogResult.Yes)
                 {
 
                     if (_index.IsIndexLocked(XivDataFile._0A_Exd))
                     {
-                        FlexibleMessageBox.Show(_win32Window, UIMessages.IndexLockedBackupFailedMessage,
+                        FlexibleMessageBox.Show(_mainWindow.Win32Window, UIMessages.IndexLockedBackupFailedMessage,
                             UIMessages.BackupFailedTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                         return;
                     }
@@ -531,7 +529,7 @@ namespace FFXIV_TexTools.ViewModels
                     }
                     catch (Exception ex)
                     {
-                        FlexibleMessageBox.Show(_win32Window, string.Format(UIMessages.BackupFailedErrorMessage, ex.Message),
+                        FlexibleMessageBox.Show(_mainWindow.Win32Window, string.Format(UIMessages.BackupFailedErrorMessage, ex.Message),
                             UIMessages.BackupFailedTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                         return;
                     }
@@ -547,7 +545,7 @@ namespace FFXIV_TexTools.ViewModels
                         }
                         catch (Exception e)
                         {
-                            FlexibleMessageBox.Show(_win32Window, string.Format(UIMessages.BackupFailedErrorMessage, e.Message),
+                            FlexibleMessageBox.Show(_mainWindow.Win32Window, string.Format(UIMessages.BackupFailedErrorMessage, e.Message),
                                 UIMessages.BackupFailedTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -350,9 +350,10 @@ namespace FFXIV_TexTools.ViewModels
             }
 
             PartComboboxEnabled = _partCount > 1;
+
             SelectedPartIndex = 0;
 
-            if (_partCount <= 1)
+            if (_partCount == 0)
             {
                 // If there are no parts, we're done.
                 if (LoadingComplete != null)
@@ -522,6 +523,15 @@ namespace FFXIV_TexTools.ViewModels
             else
             {
                 GetMaps();
+            }
+
+            if (_typeCount == 0)
+            {
+                // If there are no parts, we're done.
+                if (LoadingComplete != null)
+                {
+                    LoadingComplete.Invoke(this, null);
+                }
             }
         }
 

--- a/FFXIV_TexTools/Views/Models/ImportModelView.xaml
+++ b/FFXIV_TexTools/Views/Models/ImportModelView.xaml
@@ -5,9 +5,15 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d"
-        Title="Model Importer" Height="210" IsMinButtonEnabled="False" IsMaxRestoreButtonEnabled="False" WindowStartupLocation="CenterOwner" FontSize="14" Width="640" ResizeMode="NoResize">
+        Title="Model Importer" Height="250" IsMinButtonEnabled="False" IsMaxRestoreButtonEnabled="False" WindowStartupLocation="CenterOwner" FontSize="14" Width="640" ResizeMode="NoResize">
     <Grid>
-        <Grid Height="54" VerticalAlignment="Top">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="60"></RowDefinition>
+            <RowDefinition Height="120"></RowDefinition>
+            <RowDefinition Height="40"></RowDefinition>
+            <RowDefinition Height="1*"></RowDefinition>
+        </Grid.RowDefinitions>
+        <Grid VerticalAlignment="Top" Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="223*"/>
                 <ColumnDefinition Width="39*"/>
@@ -18,19 +24,20 @@
             <Button x:Name="UseExistingButton" Content="Use Existing" Grid.ColumnSpan="1" Margin="5,14,10,14" VerticalAlignment="Center" Grid.Column="2" Height="26" Click="UseExistingButton_Click" />
 
         </Grid>
-        <UniformGrid Margin="10,59,10,0" Columns="3" Rows="2" Height="72" VerticalAlignment="Top">
+        <UniformGrid Margin="10,10,10,10" Columns="3" Rows="3"  Grid.Row="1">
             <CheckBox x:Name="EnableShapeDataButton" Content="Enable Shape Data" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Enable the model's original shape data. (Should be ON for Faces)" />
             <CheckBox x:Name="ClearUV2Button" Content="Clear UV2" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the second UV layer to [0,0]" />
             <CheckBox x:Name="ClearVColorButton" Content="Clear Vertex Color" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the Vertex Color to [255,255,255]" />
             <CheckBox x:Name="ForceUVsButton" Content="Force UV1 to [1,-1]" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Move all UV Coordinates into the [1,-1] quadrant."  />
             <CheckBox x:Name="CloneUV1Button" Content="Clone UV1 to UV2" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Copy UV1 into UV2. (Useful for Hair shader items)"  />
             <CheckBox x:Name="ClearVAlphaButton" Content="Clear Vertex Alpha" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the Vertex Alpha to [255]" />
+            <CheckBox x:Name="AutoScaleButton" Content="Automatically Adjust Scale" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Automatically attempt to fix errors caused by improper unit scalings." />
         </UniformGrid>
-        <UniformGrid Margin="10,135,10,0" Columns="3" Height="30" VerticalAlignment="Top">
+        <UniformGrid Margin="10,5,10,5" Columns="3" Grid.Row="2">
             <Button x:Name="CancelButton" Content="Cancel" Margin="0,0,10,0" Click="CancelButton_Click"  />
             <Button x:Name="EditButton" Content="Open Editor" Margin="0" />
             <Button x:Name="ImportButton" Content="Import" Margin="10,0,0,0" />
         </UniformGrid>
-        <RichTextBox x:Name="LogTextBox" Block.LineHeight="2" Height="418" Margin="8,183,8,0" VerticalAlignment="Top" Background="#FFE2E2E2" Foreground="Black" FontFamily="Courier New" VerticalScrollBarVisibility="Visible" Padding="5" IsUndoEnabled="True" IsReadOnly="True" mah:TextBoxHelper.WatermarkWrapping="Wrap"/>
+        <RichTextBox x:Name="LogTextBox" Block.LineHeight="2" Height="418"  Grid.Row="3" Margin="8,0,8,0" VerticalAlignment="Top" Background="#FFE2E2E2" Foreground="Black" FontFamily="Courier New" VerticalScrollBarVisibility="Visible" Padding="5" IsUndoEnabled="True" IsReadOnly="True" mah:TextBoxHelper.WatermarkWrapping="Wrap"/>
     </Grid>
 </mah:MetroWindow>

--- a/FFXIV_TexTools/Views/Models/ImportModelView.xaml
+++ b/FFXIV_TexTools/Views/Models/ImportModelView.xaml
@@ -24,15 +24,28 @@
             <Button x:Name="UseExistingButton" Content="Use Existing" Grid.ColumnSpan="1" Margin="5,14,10,14" VerticalAlignment="Center" Grid.Column="2" Height="26" Click="UseExistingButton_Click" />
 
         </Grid>
-        <UniformGrid Margin="10,10,10,10" Columns="3" Rows="3"  Grid.Row="1">
-            <CheckBox x:Name="EnableShapeDataButton" Content="Enable Shape Data" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Enable the model's original shape data. (Should be ON for Faces)" />
-            <CheckBox x:Name="ClearUV2Button" Content="Clear UV2" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the second UV layer to [0,0]" />
-            <CheckBox x:Name="ClearVColorButton" Content="Clear Vertex Color" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the Vertex Color to [255,255,255]" />
-            <CheckBox x:Name="ForceUVsButton" Content="Force UV1 to [1,-1]" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Move all UV Coordinates into the [1,-1] quadrant."  />
-            <CheckBox x:Name="CloneUV1Button" Content="Clone UV1 to UV2" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Copy UV1 into UV2. (Useful for Hair shader items)"  />
-            <CheckBox x:Name="ClearVAlphaButton" Content="Clear Vertex Alpha" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the Vertex Alpha to [255]" />
-            <CheckBox x:Name="AutoScaleButton" Content="Automatically Adjust Scale" Style="{DynamicResource SimpleCheckBox}" VerticalContentAlignment="Center" VerticalAlignment="Top" ToolTipService.ShowOnDisabled="True" ToolTip="Automatically attempt to fix errors caused by improper unit scalings." />
-        </UniformGrid>
+        <Grid Margin="10,10,10,10" Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*"></ColumnDefinition>
+                <ColumnDefinition Width="1*"></ColumnDefinition>
+                <ColumnDefinition Width="1*"></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height ="1*"></RowDefinition>
+                <RowDefinition Height ="1*"></RowDefinition>
+                <RowDefinition Height ="1*"></RowDefinition>
+            </Grid.RowDefinitions>
+            <CheckBox x:Name="EnableShapeDataButton" Content="Enable Shape Data" Style="{DynamicResource SimpleCheckBox}" Grid.Row="0" Grid.Column="0" VerticalContentAlignment="Center" VerticalAlignment="Center" ToolTipService.ShowOnDisabled="True" ToolTip="Enable the model's original shape data. (Should be ON for Faces)" />
+            <CheckBox x:Name="ClearUV2Button" Content="Clear UV2" Style="{DynamicResource SimpleCheckBox}" Grid.Row="0" Grid.Column="1"  VerticalContentAlignment="Center" VerticalAlignment="Center" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the second UV layer to [0,0]" />
+            <CheckBox x:Name="ClearVColorButton" Content="Clear Vertex Color" Style="{DynamicResource SimpleCheckBox}" Grid.Row="0" Grid.Column="2"  VerticalContentAlignment="Center" VerticalAlignment="Center" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the Vertex Color to [255,255,255]" />
+            <CheckBox x:Name="ForceUVsButton" Content="Force UV1 to [1,-1]" Style="{DynamicResource SimpleCheckBox}" Grid.Row="1" Grid.Column="0"  VerticalContentAlignment="Center" VerticalAlignment="Center" ToolTipService.ShowOnDisabled="True" ToolTip="Move all UV Coordinates into the [1,-1] quadrant."  />
+            <CheckBox x:Name="CloneUV1Button" Content="Clone UV1 to UV2" Style="{DynamicResource SimpleCheckBox}" Grid.Row="1" Grid.Column="1" VerticalContentAlignment="Center" VerticalAlignment="Center" ToolTipService.ShowOnDisabled="True" ToolTip="Copy UV1 into UV2. (Useful for Hair shader items)"  />
+            <CheckBox x:Name="ClearVAlphaButton" Content="Clear Vertex Alpha" Style="{DynamicResource SimpleCheckBox}" Grid.Row="1" Grid.Column="2" VerticalContentAlignment="Center" VerticalAlignment="Center" ToolTipService.ShowOnDisabled="True" ToolTip="Reset the Vertex Alpha to [255]" />
+            <CheckBox x:Name="AutoScaleButton" Content="Automatically Adjust Scale" Style="{DynamicResource SimpleCheckBox}" Grid.Row="2" Grid.Column="0" VerticalContentAlignment="Center" VerticalAlignment="Center" ToolTipService.ShowOnDisabled="True" ToolTip="Automatically attempt to fix errors caused by improper unit scalings." />
+
+            <CheckBox x:Name="OverrideRaceButton" Content="Override Incoming Race:" Style="{DynamicResource SimpleCheckBox}" Grid.Row="2" Grid.Column="1" VerticalContentAlignment="Center" VerticalAlignment="Center" ToolTipService.ShowOnDisabled="True" ToolTip="Make TexTools convert your model from a different race to appropriate one for this item." />
+            <ComboBox Grid.Row="2" Grid.Column="2" x:Name="RaceComboBox" Width="200" VerticalAlignment="Center"></ComboBox>
+        </Grid>
         <UniformGrid Margin="10,5,10,5" Columns="3" Grid.Row="2">
             <Button x:Name="CancelButton" Content="Cancel" Margin="0,0,10,0" Click="CancelButton_Click"  />
             <Button x:Name="EditButton" Content="Open Editor" Margin="0" />


### PR DESCRIPTION
Adds some Model Import Editor QoL items 
 - Auto-Rescale for correcting import unit scale errors
 - Racial scaling on Import
 - Automatically include list of known valid attributes and materials for the drop down menus in the editor.

Adds Download Index Backups functionality.
Index Backup functionality now backs up *all* indexes, rather than just the ones TT commonly modifies.