### PR TITLE
Add Lumina as dependency, add support for Lumina saving to settings

### DIFF
--- a/FFXIV_TexTools/App.config
+++ b/FFXIV_TexTools/App.config
@@ -112,6 +112,12 @@
             <setting name="ExportAllBones" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="Lumina_Directory" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="Lumina_IsEnabled" serializeAs="String">
+                <value>False</value>
+            </setting>
         </FFXIV_TexTools.Properties.Settings>
     </userSettings>
   <runtime>
@@ -181,6 +187,10 @@
       <dependentAssembly>
         <assemblyIdentity name="HelixToolkit" publicKeyToken="52aa3500039caf0d" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.9.0.0" newVersion="2.9.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/FFXIV_TexTools/FFXIV_TexTools.csproj
+++ b/FFXIV_TexTools/FFXIV_TexTools.csproj
@@ -86,6 +86,12 @@
     <Reference Include="HelixToolkit.Wpf.SharpDX, Version=2.9.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
       <HintPath>..\packages\HelixToolkit.Wpf.SharpDX.2.9.0\lib\net45\HelixToolkit.Wpf.SharpDX.dll</HintPath>
     </Reference>
+    <Reference Include="IndexRange, Version=1.0.0.0, Culture=neutral, PublicKeyToken=35e6a3c4212514c6, processorArchitecture=MSIL">
+      <HintPath>..\packages\IndexRange.1.0.0\lib\net471\IndexRange.dll</HintPath>
+    </Reference>
+    <Reference Include="Lumina, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lumina.2.5.1\lib\netstandard2.0\Lumina.dll</HintPath>
+    </Reference>
     <Reference Include="MahApps.Metro, Version=1.6.5.1, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.6.5\lib\net47\MahApps.Metro.dll</HintPath>
     </Reference>
@@ -138,7 +144,11 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ComponentModel.Annotations.4.7.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.ComponentModel.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ComponentModel.Primitives.4.3.0\lib\net45\System.ComponentModel.Primitives.dll</HintPath>
       <Private>True</Private>

--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -53,7 +53,9 @@ using xivModdingFramework.Mods.DataContainers;
 using xivModdingFramework.Mods.FileTypes;
 using xivModdingFramework.SqPack.FileTypes;
 using static xivModdingFramework.Cache.XivCache;
+
 using Application = System.Windows.Application;
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
 
 namespace FFXIV_TexTools
 {

--- a/FFXIV_TexTools/Properties/Settings.Designer.cs
+++ b/FFXIV_TexTools/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace FFXIV_TexTools.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -428,6 +428,30 @@ namespace FFXIV_TexTools.Properties {
             }
             set {
                 this["ExportAllBones"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string Lumina_Directory {
+            get {
+                return ((string)(this["Lumina_Directory"]));
+            }
+            set {
+                this["Lumina_Directory"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Lumina_IsEnabled {
+            get {
+                return ((bool)(this["Lumina_IsEnabled"]));
+            }
+            set {
+                this["Lumina_IsEnabled"] = value;
             }
         }
     }

--- a/FFXIV_TexTools/Properties/Settings.settings
+++ b/FFXIV_TexTools/Properties/Settings.settings
@@ -104,5 +104,11 @@
     <Setting Name="ExportAllBones" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="Lumina_Directory" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="Lumina_IsEnabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FFXIV_TexTools/Resources/UIStrings.Designer.cs
+++ b/FFXIV_TexTools/Resources/UIStrings.Designer.cs
@@ -1179,6 +1179,24 @@ namespace FFXIV_TexTools.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lumina Output Directory.
+        /// </summary>
+        public static string Lumina_Directory {
+            get {
+                return ResourceManager.GetString("Lumina_Directory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Lumina Output.
+        /// </summary>
+        public static string Lumina_Output {
+            get {
+                return ResourceManager.GetString("Lumina_Output", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Manage Mod List.
         /// </summary>
         public static string Manage_ModList {

--- a/FFXIV_TexTools/Resources/UIStrings.resx
+++ b/FFXIV_TexTools/Resources/UIStrings.resx
@@ -300,6 +300,9 @@
   <data name="Colors_Skins" xml:space="preserve">
     <value>Colors &amp; Skins</value>
   </data>
+  <data name="Lumina_Output" xml:space="preserve">
+    <value>Lumina Output</value>
+  </data>
   <data name="Count" xml:space="preserve">
     <value>Count</value>
   </data>
@@ -359,6 +362,9 @@
   </data>
   <data name="FFXIV_Directory" xml:space="preserve">
     <value>FFXIV Directory</value>
+  </data>
+  <data name="Lumina_Directory" xml:space="preserve">
+    <value>Lumina Output Directory</value>
   </data>
   <data name="Filter_By_colon" xml:space="preserve">
     <value>Filter By:</value>

--- a/FFXIV_TexTools/ViewModels/CustomizeViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/CustomizeViewModel.cs
@@ -755,33 +755,6 @@ namespace FFXIV_TexTools.ViewModels
 
             if (folderSelect.ShowDialog())
             {
-                if (FlexibleMessageBox.Show(UIMessages.MoveDataMessage,
-                        UIMessages.MoveDataTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
-                {
-                    try
-                    {
-                        Directory.Move(oldSaveLocation, folderSelect.FileName);
-                    }
-                    catch
-                    {
-                        var newLoc = folderSelect.FileName;
-
-                        foreach (var dirPath in Directory.GetDirectories(oldSaveLocation, "*",
-                            SearchOption.AllDirectories))
-                        {
-                            Directory.CreateDirectory(dirPath.Replace(oldSaveLocation, newLoc));
-                        }
-
-                        foreach (var newPath in Directory.GetFiles(oldSaveLocation, "*.*",
-                            SearchOption.AllDirectories))
-                        {
-                            File.Copy(newPath, newPath.Replace(oldSaveLocation, newLoc), true);
-                        }
-
-                        DeleteDirectory(oldSaveLocation);
-                    }
-                }
-
                 var metaPath = Path.Combine(folderSelect.FileName, "meta.json");
                 if (!File.Exists(metaPath))
                     File.WriteAllText(metaPath, "{\"FileVersion\":0,\"Name\":\"TexTools Redirected Exports\",\"Author\":\"TexTools\",\"Description\":\"TexTools Redirected Exports\",\"Version\":null,\"Website\":null,\"ChangedItems\":[],\"FileSwaps\":{},\"Groups\":{}}");

--- a/FFXIV_TexTools/ViewModels/CustomizeViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/CustomizeViewModel.cs
@@ -122,6 +122,15 @@ namespace FFXIV_TexTools.ViewModels
         }
 
         /// <summary>
+        /// The lumina directory
+        /// </summary>
+        public string Lumina_Directory
+        {
+            get => !string.IsNullOrEmpty(Settings.Default.Lumina_Directory) ? Path.GetFullPath(Settings.Default.Lumina_Directory) : string.Empty;
+            set => NotifyPropertyChanged(nameof(Lumina_Directory));
+        }
+
+        /// <summary>
         /// The default author
         /// </summary>
         public string DefaultAuthor
@@ -390,6 +399,28 @@ namespace FFXIV_TexTools.ViewModels
         }
 
         /// <summary>
+        /// Lumina enabled state
+        /// </summary>
+        public bool UseLuminaExports
+        {
+            get => Settings.Default.Lumina_IsEnabled;
+            set
+            {
+                if (UseLuminaExports != value)
+                {
+                    SetLuminaExports(value);
+                    NotifyPropertyChanged(nameof(UseLuminaExports));
+                }
+            }
+        }
+
+        public void SetLuminaExports(bool value)
+        {
+            Settings.Default.Lumina_IsEnabled = value;
+            Settings.Default.Save();
+        }
+
+        /// <summary>
         /// The selected skin type
         /// </summary>
         public bool UseSynchronizedViews
@@ -528,6 +559,7 @@ namespace FFXIV_TexTools.ViewModels
         public ICommand Save_SelectDir => new RelayCommand(SaveSelectDir);
         public ICommand Backup_SelectDir => new RelayCommand(BackupSelectDir);
         public ICommand ModPack_SelectDir => new RelayCommand(ModPackSelectDir);
+        public ICommand Lumina_SelectDir => new RelayCommand(LuminaSelectDir);
         public ICommand Customize_Reset => new RelayCommand(ResetToDefault);
         public ICommand CloseCustomize => new RelayCommand(CustomizeClose);
 
@@ -706,6 +738,60 @@ namespace FFXIV_TexTools.ViewModels
                 FlexibleMessageBox.Show(string.Format(UIMessages.ModPacksLocationChangedMessage, folderSelect.FileName), UIMessages.NewDirectoryTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                 ModPack_Directory = Settings.Default.ModPack_Directory;
+            }
+        }
+
+        /// <summary>
+        /// The select lumina directory command
+        /// </summary>
+        private void LuminaSelectDir(object obj)
+        {
+            var oldSaveLocation = Lumina_Directory;
+            var folderSelect = new FolderSelectDialog
+            {
+                Title = UIMessages.NewSaveLocationTitle,
+                InitialDirectory = oldSaveLocation
+            };
+
+            if (folderSelect.ShowDialog())
+            {
+                if (FlexibleMessageBox.Show(UIMessages.MoveDataMessage,
+                        UIMessages.MoveDataTitle, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                {
+                    try
+                    {
+                        Directory.Move(oldSaveLocation, folderSelect.FileName);
+                    }
+                    catch
+                    {
+                        var newLoc = folderSelect.FileName;
+
+                        foreach (var dirPath in Directory.GetDirectories(oldSaveLocation, "*",
+                            SearchOption.AllDirectories))
+                        {
+                            Directory.CreateDirectory(dirPath.Replace(oldSaveLocation, newLoc));
+                        }
+
+                        foreach (var newPath in Directory.GetFiles(oldSaveLocation, "*.*",
+                            SearchOption.AllDirectories))
+                        {
+                            File.Copy(newPath, newPath.Replace(oldSaveLocation, newLoc), true);
+                        }
+
+                        DeleteDirectory(oldSaveLocation);
+                    }
+                }
+
+                var metaPath = Path.Combine(folderSelect.FileName, "meta.json");
+                if (!File.Exists(metaPath))
+                    File.WriteAllText(metaPath, "{\"FileVersion\":0,\"Name\":\"TexTools Redirected Exports\",\"Author\":\"TexTools\",\"Description\":\"TexTools Redirected Exports\",\"Version\":null,\"Website\":null,\"ChangedItems\":[],\"FileSwaps\":{},\"Groups\":{}}");
+
+                Settings.Default.Lumina_Directory = folderSelect.FileName;
+                Settings.Default.Save();
+
+                FlexibleMessageBox.Show(string.Format(UIMessages.SavedLocationChangedMessage, folderSelect.FileName), UIMessages.NewDirectoryTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+                Lumina_Directory = Settings.Default.Lumina_Directory;
             }
         }
 

--- a/FFXIV_TexTools/ViewModels/FullModelViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/FullModelViewModel.cs
@@ -41,6 +41,8 @@ using xivModdingFramework.Models.ModelTextures;
 using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Variants.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.ViewModels
 {
     public class FullModelViewModel : INotifyPropertyChanged

--- a/FFXIV_TexTools/ViewModels/ImportModelViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ImportModelViewModel.cs
@@ -283,11 +283,11 @@ namespace FFXIV_TexTools.ViewModels
                {
                    if (showEditor)
                    {
-                       await _mdl.ImportModel(_item, _race, path, options, LogMessageReceived, IntermediateStep, XivStrings.TexTools, _submeshId, _dataOnly);
+                       await _mdl.ImportModel(_item, _race, path, options, LogMessageReceived, IntermediateStep, XivStrings.TexTools, _submeshId, _dataOnly, Settings.Default.Lumina_IsEnabled, new DirectoryInfo(Settings.Default.Lumina_Directory));
                    }
                    else
                    {
-                       await _mdl.ImportModel(_item, _race, path, options, LogMessageReceived, null, XivStrings.TexTools, _submeshId, _dataOnly);
+                       await _mdl.ImportModel(_item, _race, path, options, LogMessageReceived, null, XivStrings.TexTools, _submeshId, _dataOnly, Settings.Default.Lumina_IsEnabled, new DirectoryInfo(Settings.Default.Lumina_Directory));
                    }
                    OnImportComplete();
                }

--- a/FFXIV_TexTools/ViewModels/MainViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/MainViewModel.cs
@@ -45,6 +45,8 @@ using FFXIV_TexTools.Views;
 using xivModdingFramework.Mods.DataContainers;
 using xivModdingFramework.SqPack.DataContainers;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.ViewModels
 {
     public class MainViewModel : INotifyPropertyChanged

--- a/FFXIV_TexTools/ViewModels/MaterialEditorViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/MaterialEditorViewModel.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
+using FFXIV_TexTools.Properties;
 using xivModdingFramework.Cache;
 using xivModdingFramework.General.Enums;
 using xivModdingFramework.Items;
@@ -26,6 +27,8 @@ using xivModdingFramework.Textures.Enums;
 using xivModdingFramework.Variants.DataContainers;
 using xivModdingFramework.Variants.FileTypes;
 using Constants = xivModdingFramework.Helpers.Constants;
+
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
 
 namespace FFXIV_TexTools.ViewModels
 {
@@ -309,7 +312,7 @@ namespace FFXIV_TexTools.ViewModels
                 if (_mode == MaterialEditorMode.NewSingle || _mode == MaterialEditorMode.EditSingle)
                 {
                     // Save the existing MTRL.
-                    await _mtrl.ImportMtrl(_material, _item, XivStrings.TexTools);
+                    await _mtrl.ImportMtrl(_material, _item, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: new DirectoryInfo(Settings.Default.Lumina_Directory ?? string.Empty));
                 }
                 else if (_mode == MaterialEditorMode.NewMulti || _mode == MaterialEditorMode.EditMulti || _mode == MaterialEditorMode.NewRace)
                 {
@@ -430,7 +433,7 @@ namespace FFXIV_TexTools.ViewModels
             // We need to save our non-existent base material once before we can continue.
             if (_mode == MaterialEditorMode.NewRace)
             {
-                await _mtrl.ImportMtrl(_material, _item, XivStrings.TexTools);
+                await _mtrl.ImportMtrl(_material, _item, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: new DirectoryInfo(Settings.Default.Lumina_Directory ?? string.Empty));
             }
 
             var count = 0;
@@ -524,7 +527,7 @@ namespace FFXIV_TexTools.ViewModels
 
                 count++;
                 // Write the new Material
-                await _mtrl.ImportMtrl(itemXivMtrl, item, XivStrings.TexTools);
+                await _mtrl.ImportMtrl(itemXivMtrl, item, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: new DirectoryInfo(Settings.Default.Lumina_Directory ?? string.Empty));
                 _view.SaveStatusLabel.Content = "Updated " + count + "/" + materialSets.Count + " Material Sets...";
             }
 

--- a/FFXIV_TexTools/ViewModels/MetadataViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/MetadataViewModel.cs
@@ -2,9 +2,11 @@
 using FFXIV_TexTools.Views.Metadata;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FFXIV_TexTools.Properties;
 using xivModdingFramework.Cache;
 using xivModdingFramework.General.Enums;
 using xivModdingFramework.Helpers;
@@ -119,7 +121,8 @@ namespace FFXIV_TexTools.ViewModels
             {
                 await MainWindow.GetMainWindow().LockUi("Updating Metadata");
 
-                await ItemMetadata.SaveMetadata(_metadata, XivStrings.TexTools);
+                var luminaPath = new DirectoryInfo(Settings.Default.Lumina_Directory ?? string.Empty);
+                await ItemMetadata.SaveMetadata(_metadata, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: luminaPath);
 
                 var _mdl = new Mdl(XivCache.GameInfo.GameDirectory, IOUtil.GetDataFileFromPath(_metadata.Root.Info.GetRootFile()));
 
@@ -129,7 +132,7 @@ namespace FFXIV_TexTools.ViewModels
                     if (_original.EqdpEntries[kv.Key].bit1 == true) continue;
 
                     // Here we have a new race, we need to create a model for it.
-                    await _mdl.AddRacialModel(_metadata.Root.Info.PrimaryId, _metadata.Root.Info.Slot, kv.Key, XivStrings.TexTools);
+                    await _mdl.AddRacialModel(_metadata.Root.Info.PrimaryId, _metadata.Root.Info.Slot, kv.Key, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: luminaPath);
                 }
 
                 if(_metadata.ImcEntries.Count > 0)
@@ -152,7 +155,7 @@ namespace FFXIV_TexTools.ViewModels
                             {
                                 var dest = material.Replace("v0001", "v" + i.ToString().PadLeft(4, '0'));
 
-                                await _dat.CopyFile(material, dest, XivStrings.TexTools, false, item);
+                                await _dat.CopyFile(material, dest, XivStrings.TexTools, false, item, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: luminaPath);
                             }
                         }
                     }

--- a/FFXIV_TexTools/ViewModels/ModelViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModelViewModel.cs
@@ -1617,7 +1617,7 @@ namespace FFXIV_TexTools.ViewModels
             var gameDirectory = new DirectoryInfo(Settings.Default.FFXIV_Directory);
             var index = new Index(gameDirectory);
 
-            if (index.IsIndexLocked(XivDataFile._0A_Exd))
+            if (index.IsIndexLocked(XivDataFile._0A_Exd) && !Settings.Default.Lumina_IsEnabled)
             {
                 FlexibleMessageBox.Show(UIMessages.IndexLockedErrorMessage,
                     UIMessages.IndexLockedErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/FFXIV_TexTools/ViewModels/ModelViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModelViewModel.cs
@@ -55,10 +55,12 @@ using xivModdingFramework.Models.ModelTextures;
 using xivModdingFramework.Mods;
 using xivModdingFramework.Mods.Enums;
 using xivModdingFramework.SqPack.FileTypes;
+
 using Color = SharpDX.Color;
 using ColorConverter = System.Windows.Media.ColorConverter;
 using Timer = System.Timers.Timer;
 using WinColor = System.Windows.Media.Color;
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
 
 namespace FFXIV_TexTools.ViewModels
 {

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -66,7 +66,9 @@ using xivModdingFramework.Textures.Enums;
 using xivModdingFramework.Textures.FileTypes;
 using xivModdingFramework.Variants.DataContainers;
 using xivModdingFramework.Variants.FileTypes;
+
 using BitmapSource = System.Windows.Media.Imaging.BitmapSource;
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
 
 namespace FFXIV_TexTools.ViewModels
 {
@@ -1579,6 +1581,8 @@ namespace FFXIV_TexTools.ViewModels
             var fileDir = new DirectoryInfo(fileName);
             var dxVersion = int.Parse(Settings.Default.DX_Version);
 
+            var luminaOutDir = new DirectoryInfo(Settings.Default.Lumina_Directory ?? string.Empty);
+
             if (fileDir.FullName.ToLower().Contains(".dds"))
             {
                 if (SelectedMap.Usage != XivTexType.ColorSet)
@@ -1600,11 +1604,11 @@ namespace FFXIV_TexTools.ViewModels
                                 saveItem = temp;
                             }
 
-                            await _tex.ImportTex(texData.TextureTypeAndPath.Path, fileDir.FullName, saveItem, XivStrings.TexTools);
+                            await _tex.ImportTex(texData.TextureTypeAndPath.Path, fileDir.FullName, saveItem, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: luminaOutDir);
                         }
                         else if (_uiItem != null)
                         {
-                            await _tex.ImportTex(texData.TextureTypeAndPath.Path, fileDir.FullName, _uiItem, XivStrings.TexTools);
+                            await _tex.ImportTex(texData.TextureTypeAndPath.Path, fileDir.FullName, _uiItem, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: luminaOutDir);
                         }
                     }
                     catch (Exception ex)
@@ -1619,7 +1623,7 @@ namespace FFXIV_TexTools.ViewModels
                 {
                     try
                     {
-                        var newColorSetOffset = await _tex.TexColorImporter(_xivMtrl, fileDir, _item, XivStrings.TexTools, GetLanguage());
+                        var newColorSetOffset = await _tex.TexColorImporter(_xivMtrl, fileDir, _item, XivStrings.TexTools, GetLanguage(), doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: luminaOutDir);
                         _xivMtrl = await _mtrl.GetMtrlData(newColorSetOffset, _xivMtrl.MTRLPath, dxVersion);
                     }
                     catch (Exception ex)
@@ -1651,11 +1655,11 @@ namespace FFXIV_TexTools.ViewModels
                                 saveItem = temp;
                             }
 
-                            await _tex.ImportTex(texData.TextureTypeAndPath.Path, fileDir.FullName, _item, XivStrings.TexTools);
+                            await _tex.ImportTex(texData.TextureTypeAndPath.Path, fileDir.FullName, _item, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: luminaOutDir);
                         }
                         else if (_uiItem != null)
                         {
-                            await _tex.ImportTex(texData.TextureTypeAndPath.Path, fileDir.FullName, _uiItem, XivStrings.TexTools);
+                            await _tex.ImportTex(texData.TextureTypeAndPath.Path, fileDir.FullName, _uiItem, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: luminaOutDir);
                         }
                     }
                     catch (Exception ex)

--- a/FFXIV_TexTools/Views/Controls/ColorsetEditorControl.xaml.cs
+++ b/FFXIV_TexTools/Views/Controls/ColorsetEditorControl.xaml.cs
@@ -23,6 +23,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using FFXIV_TexTools.Properties;
 using xivModdingFramework.Cache;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.Materials.DataContainers;
@@ -495,7 +496,7 @@ namespace FFXIV_TexTools.Controls
                 var mtrlLib = new Mtrl(XivCache.GameInfo.GameDirectory);
 
                 var item = mw.GetSelectedItem();
-                await mtrlLib.ImportMtrl(_mtrl, item, XivStrings.TexTools);
+                await mtrlLib.ImportMtrl(_mtrl, item, XivStrings.TexTools, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: new DirectoryInfo(Settings.Default.Lumina_Directory ?? string.Empty));
                 MaterialSaved.Invoke(this, null);
             }
             catch(Exception ex)

--- a/FFXIV_TexTools/Views/Controls/ItemInfoDisplay.xaml.cs
+++ b/FFXIV_TexTools/Views/Controls/ItemInfoDisplay.xaml.cs
@@ -26,6 +26,8 @@ using xivModdingFramework.Models.FileTypes;
 using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Variants.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.Views.Controls
 {
     /// <summary>

--- a/FFXIV_TexTools/Views/CopyFileDialog.xaml.cs
+++ b/FFXIV_TexTools/Views/CopyFileDialog.xaml.cs
@@ -7,6 +7,8 @@ using System.Windows;
 using xivModdingFramework.Cache;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.Views
 {
     /// <summary>

--- a/FFXIV_TexTools/Views/CopyFileDialog.xaml.cs
+++ b/FFXIV_TexTools/Views/CopyFileDialog.xaml.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
+using FFXIV_TexTools.Properties;
 using xivModdingFramework.Cache;
 using xivModdingFramework.SqPack.FileTypes;
 
@@ -60,7 +61,7 @@ namespace FFXIV_TexTools.Views
                     if (cancel) return;
                 }
 
-                await _dat.CopyFile(from, to, XivStrings.TexTools, true);
+                await _dat.CopyFile(from, to, XivStrings.TexTools, true, doLumina: Settings.Default.Lumina_IsEnabled, luminaOutDir: new DirectoryInfo(Settings.Default.Lumina_Directory ?? string.Empty));
 
                 Dispatcher.Invoke(() =>
                 {

--- a/FFXIV_TexTools/Views/CopyModelDialog.xaml.cs
+++ b/FFXIV_TexTools/Views/CopyModelDialog.xaml.cs
@@ -2,6 +2,7 @@
 using FFXIV_TexTools.Resources;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -14,6 +15,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using FFXIV_TexTools.Properties;
 using xivModdingFramework.Cache;
 using xivModdingFramework.General.Enums;
 using xivModdingFramework.Helpers;
@@ -154,7 +156,7 @@ namespace FFXIV_TexTools.Views
 
                 var _mdl = new Mdl(XivCache.GameInfo.GameDirectory, df);
 
-                await _mdl.CopyModel(from, to, XivStrings.TexTools, true);
+                await _mdl.CopyModel(from, to, XivStrings.TexTools, true, Settings.Default.Lumina_IsEnabled, new DirectoryInfo(Settings.Default.Lumina_Directory ?? string.Empty));
                 FlexibleMessageBox.Show("Model Copied Successfully.", "Model Copy Confirmation", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
                 Close();
             }

--- a/FFXIV_TexTools/Views/CustomizeSettingsView.xaml
+++ b/FFXIV_TexTools/Views/CustomizeSettingsView.xaml
@@ -167,7 +167,7 @@
                         </Grid.RowDefinitions>
 
                         <Label Grid.Column="0" Grid.Row="1"  Margin="10,0,5,0" Content="Redirect imports to Lumina" VerticalAlignment="Center" HorizontalContentAlignment="Right" VerticalContentAlignment="Center"></Label>
-                        <CheckBox x:Name="EnableLuminaCheckBox"  Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" Margin="5,0,10,0"  IsChecked="{Binding UseLuminaExports}" ToolTip="Export to the selected folder in Lumina/Umbra/Penumbra formats instead of local game files."></CheckBox>
+                        <CheckBox x:Name="EnableLuminaCheckBox"  Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" Margin="5,0,10,0"  IsChecked="{Binding UseLuminaExports}" ToolTip="Redirect imports and metadata changes to the selected folder in Lumina/Umbra/Penumbra formats instead of local game files."></CheckBox>
                     </Grid>
                 </StackPanel>
             </GroupBox>

--- a/FFXIV_TexTools/Views/CustomizeSettingsView.xaml
+++ b/FFXIV_TexTools/Views/CustomizeSettingsView.xaml
@@ -8,7 +8,7 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         mc:Ignorable="d"
         xmlns:resx="clr-namespace:FFXIV_TexTools.Resources"
-        Title="{Binding Source={x:Static resx:UIStrings.Customize}}" Height="600" Width="800" ShowMaxRestoreButton="False" ShowMinButton="False" WindowStartupLocation="CenterOwner">
+        Title="{Binding Source={x:Static resx:UIStrings.Customize}}" Height="620" Width="800" ShowMaxRestoreButton="False" ShowMinButton="False" WindowStartupLocation="CenterOwner">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
@@ -87,6 +87,7 @@
         <Grid Grid.Column="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition></RowDefinition>
             </Grid.RowDefinitions>
             <GroupBox Header="{Binding Source={x:Static resx:UIStrings.Colors_Skins}}" Margin="5">
@@ -140,8 +141,38 @@
                     <Button x:Name="DefaultButton" Content="{Binding Source={x:Static resx:UIStrings.Reset_to_Default}}" Command="{Binding Customize_Reset}" Grid.Row="9" Grid.Column="0" Margin="5"/>
                 </Grid>
             </GroupBox>
-            <Button x:Name="CloseButton" Grid.Row="1" Content="{Binding Source={x:Static resx:UIStrings.Close}}" Command="{Binding CloseCustomize}" Margin="10" Click="CloseButton_Click" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="150" />
 
+            <GroupBox Grid.Row="1" Header="{Binding Source={x:Static resx:UIStrings.Lumina_Output}}" Margin="5">
+                <StackPanel>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBox x:Name="LuminaOutDir" Grid.Row="0" Text="{Binding Lumina_Directory}" TextWrapping="NoWrap" IsReadOnly="True" Margin="5" mah:TextBoxHelper.Watermark="{Binding Source={x:Static resx:UIStrings.Lumina_Directory}}" mah:TextBoxHelper.UseFloatingWatermark="True"/>
+
+                        <Button Content="..." Grid.Row="0" Grid.Column="1" Margin="5" Command="{Binding Lumina_SelectDir}" HorizontalAlignment="Center" VerticalAlignment="Center" MinWidth="25" MinHeight="25" HorizontalContentAlignment="Center" VerticalContentAlignment="Top"/>
+                    </Grid>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="175"></ColumnDefinition>
+                            <ColumnDefinition></ColumnDefinition>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="36"/>
+                        </Grid.RowDefinitions>
+
+                        <Label Grid.Column="0" Grid.Row="1"  Margin="10,0,5,0" Content="Redirect imports to Lumina" VerticalAlignment="Center" HorizontalContentAlignment="Right" VerticalContentAlignment="Center"></Label>
+                        <CheckBox x:Name="EnableLuminaCheckBox"  Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" Margin="5,0,10,0"  IsChecked="{Binding UseLuminaExports}" ToolTip="Export to the selected folder in Lumina/Umbra/Penumbra formats instead of local game files."></CheckBox>
+                    </Grid>
+                </StackPanel>
+            </GroupBox>
+
+            <Button x:Name="CloseButton" Grid.Row="2" Content="{Binding Source={x:Static resx:UIStrings.Close}}" Command="{Binding CloseCustomize}" Margin="10" Click="CloseButton_Click" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="150" />
         </Grid>
     </Grid>
 </mah:MetroWindow>

--- a/FFXIV_TexTools/Views/ExtractRawDialog.xaml.cs
+++ b/FFXIV_TexTools/Views/ExtractRawDialog.xaml.cs
@@ -9,6 +9,8 @@ using xivModdingFramework.Helpers;
 using xivModdingFramework.Models.FileTypes;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.Views
 {
     /// <summary>

--- a/FFXIV_TexTools/Views/ImportRawDialog.xaml.cs
+++ b/FFXIV_TexTools/Views/ImportRawDialog.xaml.cs
@@ -16,6 +16,8 @@ using xivModdingFramework.Cache;
 using xivModdingFramework.Items.DataContainers;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.Views
 {
     /// <summary>

--- a/FFXIV_TexTools/Views/ModPack/SimpleModPackImporter.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/SimpleModPackImporter.xaml.cs
@@ -43,7 +43,9 @@ using xivModdingFramework.Mods.FileTypes;
 using xivModdingFramework.SqPack.DataContainers;
 using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Textures.Enums;
+
 using Path = System.IO.Path;
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
 
 namespace FFXIV_TexTools.Views
 {

--- a/FFXIV_TexTools/Views/ModPack/Standard/StandardModpackCreator.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/Standard/StandardModpackCreator.xaml.cs
@@ -22,6 +22,8 @@ using xivModdingFramework.Mods.DataContainers;
 using xivModdingFramework.Mods.FileTypes;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.Views
 {
     /// <summary>

--- a/FFXIV_TexTools/Views/ModPack/Standard/StandardModpackFileSelect.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/Standard/StandardModpackFileSelect.xaml.cs
@@ -21,6 +21,8 @@ using xivModdingFramework.Items.Interfaces;
 using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Variants.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.Views
 {
     /// <summary>

--- a/FFXIV_TexTools/Views/ModPack/Standard/StandardModpackFilesReview.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/Standard/StandardModpackFilesReview.xaml.cs
@@ -10,6 +10,8 @@ using System.Windows.Controls;
 using xivModdingFramework.Cache;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace FFXIV_TexTools.Views
 {
     /// <summary>

--- a/FFXIV_TexTools/Views/ModPack/WizardAddGroupWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/WizardAddGroupWindow.xaml.cs
@@ -53,7 +53,9 @@ using xivModdingFramework.Textures.DataContainers;
 using xivModdingFramework.Textures.Enums;
 using xivModdingFramework.Textures.FileTypes;
 using xivModdingFramework.Variants.FileTypes;
+
 using Image = SixLabors.ImageSharp.Image;
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
 
 namespace FFXIV_TexTools.Views
 {

--- a/FFXIV_TexTools/Views/ProblemCheckView.xaml.cs
+++ b/FFXIV_TexTools/Views/ProblemCheckView.xaml.cs
@@ -33,13 +33,15 @@ using xivModdingFramework.General.Enums;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.Mods.DataContainers;
 using xivModdingFramework.SqPack.FileTypes;
-using Application = System.Windows.Application;
 using xivModdingFramework.Cache;
 using xivModdingFramework.Mods;
 using System.Runtime.CompilerServices;
 using System.Linq;
 using FFXIV_TexTools.ViewModels;
 using xivModdingFramework.SqPack.DataContainers;
+
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+using Application = System.Windows.Application;
 
 namespace FFXIV_TexTools.Views
 {

--- a/FFXIV_TexTools/packages.config
+++ b/FFXIV_TexTools/packages.config
@@ -9,6 +9,8 @@
   <package id="HelixToolkit.SharpDX.Core" version="2.9.0" targetFramework="net472" />
   <package id="HelixToolkit.Wpf" version="2.9.0" targetFramework="net472" />
   <package id="HelixToolkit.Wpf.SharpDX" version="2.9.0" targetFramework="net472" />
+  <package id="IndexRange" version="1.0.0" targetFramework="net472" />
+  <package id="Lumina" version="2.5.1" targetFramework="net472" />
   <package id="MahApps.Metro" version="1.6.5" targetFramework="net472" />
   <package id="MahApps.Metro.IconPacks" version="2.3.0" targetFramework="net472" />
   <package id="MahApps.Metro.IconPacks.Material" version="2.3.0" targetFramework="net472" />
@@ -27,6 +29,7 @@
   <package id="SixLabors.ImageSharp" version="1.0.0-beta0007" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
   <package id="System.Collections.NonGeneric" version="4.3.0" targetFramework="net472" />
+  <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net472" />
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net472" />
   <package id="System.Data.SQLite" version="1.0.113.1" targetFramework="net472" />


### PR DESCRIPTION
This repository adds Lumina as a dependency, adds support for Lumina saving to all needed components, and updates xivModdingFramework to support these changes.

This PR depends on https://github.com/TexTools/xivModdingFramework/pull/26.