### PR TITLE
(De)Select all options for advanced import mod wizzard

### DIFF
--- a/FFXIV_TexTools/Resources/UIStrings.Designer.cs
+++ b/FFXIV_TexTools/Resources/UIStrings.Designer.cs
@@ -558,6 +558,15 @@ namespace FFXIV_TexTools.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deselect All.
+        /// </summary>
+        public static string Deselect_All {
+            get {
+                return ResourceManager.GetString("Deselect_All", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Directories.
         /// </summary>
         public static string Directories {
@@ -1688,6 +1697,15 @@ namespace FFXIV_TexTools.Resources {
         public static string New_Page {
             get {
                 return ResourceManager.GetString("New_Page", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Next Page &gt;.
+        /// </summary>
+        public static string Next_Page {
+            get {
+                return ResourceManager.GetString("Next_Page", resourceCulture);
             }
         }
         

--- a/FFXIV_TexTools/Resources/UIStrings.resx
+++ b/FFXIV_TexTools/Resources/UIStrings.resx
@@ -1039,4 +1039,10 @@ If you would like to enable this, first import a texture for the selected item.<
   <data name="Backup_Modpack" xml:space="preserve">
     <value>Backup Modpack</value>
   </data>
+  <data name="Deselect_All" xml:space="preserve">
+    <value>Deselect All</value>
+  </data>
+  <data name="Next_Page" xml:space="preserve">
+    <value>Next Page &gt;</value>
+  </data>
 </root>

--- a/FFXIV_TexTools/Views/ModPack/Wizard/ImportModPackWizard.xaml
+++ b/FFXIV_TexTools/Views/ModPack/Wizard/ImportModPackWizard.xaml
@@ -9,7 +9,7 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         mc:Ignorable="d"
         Title="{Binding Source={x:Static resx:UIStrings.Import_ModPack_Wizard}}" Height="600" Width="800" ShowMaxRestoreButton="False" ShowMinButton="False" WindowStartupLocation="CenterOwner" Closing="MetroWindow_Closing">
-    <xctk:Wizard x:Name="importModPackWizard" NextButtonContent="{Binding Source={x:Static resx:UIStrings.New_Page}}" BackButtonContent="{Binding Source={x:Static resx:UIStrings.Previous_Page}}"  Next="ImportModPackWizard_Next" CanHelp="False" HelpButtonVisibility="Collapsed" Finish="ImportModPackWizard_Finish" Previous="ImportModPackWizard_Previous" FinishButtonClosesWindow="False" FinishButtonContent="{Binding Source={x:Static resx:UIStrings.Finish}}" CancelButtonContent="{Binding Source={x:Static resx:UIStrings.Cancel}}" Background="{x:Null}">
+    <xctk:Wizard x:Name="importModPackWizard" NextButtonContent="{Binding Source={x:Static resx:UIStrings.Next_Page}}" BackButtonContent="{Binding Source={x:Static resx:UIStrings.Previous_Page}}"  Next="ImportModPackWizard_Next" CanHelp="False" HelpButtonVisibility="Collapsed" Finish="ImportModPackWizard_Finish" Previous="ImportModPackWizard_Previous" FinishButtonClosesWindow="False" FinishButtonContent="{Binding Source={x:Static resx:UIStrings.Finish}}" CancelButtonContent="{Binding Source={x:Static resx:UIStrings.Cancel}}" Background="{x:Null}">
         <xctk:WizardPage Title="{Binding Source={x:Static resx:UIStrings.Mod_Pack_Importer}}" Description="{Binding Source={x:Static resx:UIStrings.Go_through_the_wizard_and_select_relevant_options_to_import_mod_pack}}" PageType="Interior" Background="{x:Null}" HeaderBackground="{x:Null}">
             <Grid>
                 <Grid.RowDefinitions>

--- a/FFXIV_TexTools/Views/ModPack/Wizard/ImportWizardModPackControl.xaml
+++ b/FFXIV_TexTools/Views/ModPack/Wizard/ImportWizardModPackControl.xaml
@@ -29,28 +29,40 @@
         </Grid.ColumnDefinitions>
         <Grid Grid.Column="0">
             <GroupBox Grid.Row="0" Header="{Binding Source={x:Static resx:UIStrings.Options_List}}" Margin="5">
-                <ListBox x:Name="OptionsList" SelectionChanged="OptionsList_SelectionChanged" ScrollViewer.CanContentScroll="False">
-                    <ListBox.GroupStyle>
-                        <GroupStyle>
-                            <GroupStyle.HeaderTemplate>
-                                <DataTemplate>
-                                    <Border BorderThickness="0,0,0,1">
-                                        <Border.BorderBrush>
-                                            <LinearGradientBrush EndPoint="1,0" MappingMode="RelativeToBoundingBox" StartPoint="0,1">
-                                                <GradientStop Color="Black" Offset="0"/>
-                                                <GradientStop Color="White" Offset="1"/>
-                                            </LinearGradientBrush>
-                                        </Border.BorderBrush>
-                                        <TextBlock FontWeight="Bold" Text="{Binding Name}"/>
-                                    </Border>
-                                </DataTemplate>
-                            </GroupStyle.HeaderTemplate>
-                        </GroupStyle>
-                    </ListBox.GroupStyle>
-                    <ListBox.ItemTemplateSelector>
-                        <local:ImportSelectionTemplateSelector RadioButtonTemplate="{StaticResource RadioButtonTemplate}" CheckBoxTemplate="{StaticResource CheckBoxTemplate}"/>
-                    </ListBox.ItemTemplateSelector>
-                </ListBox>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="25"/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Button x:Name="SelectAllButton" Content="{Binding Source={x:Static resx:UIStrings.Select_All}}" Grid.Column="0" Click="SelectAllButton_Click"/>
+                    <Button x:Name="DeselectAllButton" Content="{Binding Source={x:Static resx:UIStrings.Deselect_All}}" Grid.Column="1" Click="DeselectAllButton_Click"/>
+                    <ListBox x:Name="OptionsList" SelectionChanged="OptionsList_SelectionChanged" ScrollViewer.CanContentScroll="False" Grid.Row="1" Grid.ColumnSpan="2">
+                        <ListBox.GroupStyle>
+                            <GroupStyle>
+                                <GroupStyle.HeaderTemplate>
+                                    <DataTemplate>
+                                        <Border BorderThickness="0,0,0,1">
+                                            <Border.BorderBrush>
+                                                <LinearGradientBrush EndPoint="1,0" MappingMode="RelativeToBoundingBox" StartPoint="0,1">
+                                                    <GradientStop Color="Black" Offset="0"/>
+                                                    <GradientStop Color="White" Offset="1"/>
+                                                </LinearGradientBrush>
+                                            </Border.BorderBrush>
+                                            <TextBlock FontWeight="Bold" Text="{Binding Name}"/>
+                                        </Border>
+                                    </DataTemplate>
+                                </GroupStyle.HeaderTemplate>
+                            </GroupStyle>
+                        </ListBox.GroupStyle>
+                        <ListBox.ItemTemplateSelector>
+                            <local:ImportSelectionTemplateSelector RadioButtonTemplate="{StaticResource RadioButtonTemplate}" CheckBoxTemplate="{StaticResource CheckBoxTemplate}"/>
+                        </ListBox.ItemTemplateSelector>
+                    </ListBox>
+                </Grid>
             </GroupBox>
         </Grid>
         <Grid Column="1">

--- a/FFXIV_TexTools/Views/ModPack/Wizard/ImportWizardModPackControl.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/Wizard/ImportWizardModPackControl.xaml.cs
@@ -142,6 +142,28 @@ namespace FFXIV_TexTools.Views
                 // No-Op
             }
         }
+
+        private void SelectAllButton_Click(object sender, RoutedEventArgs e)
+        {
+            SelectAllOptions(true);
+        }
+
+        private void DeselectAllButton_Click(object sender, RoutedEventArgs e)
+        {
+            SelectAllOptions(false);
+        }
+
+        private void SelectAllOptions(bool isSelected)
+        {
+            foreach (var item in OptionsList.ItemsSource)
+            {
+                var modOption = (ModOptionJson)item;
+                if (!modOption.SelectionType.Equals("Single"))
+                {
+                    modOption.IsChecked = isSelected;
+                }
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Adds two buttons to de/select all _multi-select_ options for an import mod wizard page. Note this does trigger `ImportWizardModPackControl.Option_Toggled` (eg. the last option will be selected as seen in the vid) but is relatively harmless.

Also fixed the **import** mod wizard "New Page >" button text to "Next Page >"

https://user-images.githubusercontent.com/10760766/133945192-45d5aa3a-2907-404d-aa01-e0267af42993.mp4

Note for this to work properly it requires submodules changes in PR https://github.com/TexTools/xivModdingFramework/pull/36