### PR TITLE
Fix `Download Index Backup` failed on non-Global client

### DIFF
--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -1562,7 +1562,7 @@ namespace FFXIV_TexTools
         private async Task DownloadIndexBackups()
         {
             var url = UIStrings.Index_Backups_Url;
-            if (url == "INVALID" || String.IsNullOrWhiteSpace(url))
+            if (url == "NONE" || String.IsNullOrWhiteSpace(url))
             {
                 FlexibleMessageBox.Show("Index backup download is not currently supported for your client language.", "Web Download Error", MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1);
                 return;


### PR DESCRIPTION
#15 introduced a new feature that user can restore index from an Internet backup. However, this function will failed on non-English/Global client. Blame e76135e97f8a2f90dbf26bb1391b0ce05770a292, this commit tried to allow variant client like Korean/China client to download index backup through other link. But it uses a wrong condition expression. This PR fix the issue.

