### PR TITLE
Export 8-bit color PNGs instead of 16-bit

### DIFF
--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -1411,7 +1411,7 @@ namespace FFXIV_TexTools.ViewModels
                 {
                     encoder = new PngEncoder()
                     {
-                        BitDepth = PngBitDepth.Bit16
+                        BitDepth = _mapData.IsColorSet ? PngBitDepth.Bit16 : PngBitDepth.Bit8
                     };
                 }
                 else
@@ -2222,7 +2222,10 @@ namespace FFXIV_TexTools.ViewModels
 
             if (AlphaChecked)
             {
-                imageEncoder = new PngEncoder();
+                imageEncoder = new PngEncoder()
+                {
+                    BitDepth = _mapData.IsColorSet ? PngBitDepth.Bit16 : PngBitDepth.Bit8
+                };
             }
             else
             {


### PR DESCRIPTION
Would this be a reasonable change?

Right now if you manually click Export on a texture you always get a 16 bits per channel PNG file, which I assume was done to keep precision for Color Maps which are floating point instead of RGBA32.

All other usages of PngEncoder in the program only output 8 bits per channel PNG files, for example the files produced alongside a model export.