### PR TITLE
Add alternate rendering method for Linux/WINE/DXVK

### DIFF
--- a/FFXIV_TexTools/App.xaml.cs
+++ b/FFXIV_TexTools/App.xaml.cs
@@ -22,6 +22,10 @@ namespace FFXIV_TexTools
 
         protected override void OnStartup(StartupEventArgs e)
         {
+            // Disable hardware acceleration of all windows if requested
+            if (Configuration.EnvironmentConfiguration.TT_Software_Rendering)
+                System.Windows.Media.RenderOptions.ProcessRenderMode = System.Windows.Interop.RenderMode.SoftwareOnly;
+
             var appStyle = ThemeManager.DetectAppStyle(Application.Current);
 
             ThemeManager.ChangeAppStyle(Application.Current, ThemeManager.GetAccent(appStyle.Item2.Name), ThemeManager.GetAppTheme(Settings.Default.Application_Theme));

--- a/FFXIV_TexTools/Configuration/EnvironmentConfiguration.cs
+++ b/FFXIV_TexTools/Configuration/EnvironmentConfiguration.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Win32;
+
+namespace FFXIV_TexTools.Configuration
+{
+    internal class EnvironmentConfiguration
+    {
+        // Disable DX9 hardware accelerated rendering of WPF UI
+        // The newest versions of DXVK no longer have major rendering issues that would require this
+        internal static bool TT_Software_Rendering = GetEnvironmentFlag("TT_SOFTWARE_RENDERING", false);
+
+        // Bypass DX11 / DX9 shared rendering, to avoid an issue with DXVK where model previews do not work
+        // If this environment variable is not set, it attempts to default to true when using WINE / Linux
+        internal static bool TT_Unshared_Rendering = GetEnvironmentFlag("TT_UNSHARED_RENDERING", DetectWINE());
+
+        static bool GetEnvironmentFlag(string varName, bool defaultValue = false)
+        {
+            try
+            {
+                string value = System.Environment.GetEnvironmentVariable(varName);
+                if (uint.TryParse(value, out var intval))
+                    return intval != 0;
+                else if (bool.TryParse(value, out var boolval))
+                    return boolval;
+                else
+                    return defaultValue;
+            }
+            catch
+            {
+                return defaultValue;
+            }
+        }
+
+        static bool DetectWINE()
+        {
+            try
+            {
+                var key = Registry.CurrentUser.OpenSubKey("Software\\Wine");
+                if (key != null)
+                {
+                    key.Dispose();
+                    return true;
+                }
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/FFXIV_TexTools/FFXIV_TexTools.csproj
+++ b/FFXIV_TexTools/FFXIV_TexTools.csproj
@@ -28,6 +28,7 @@
     <LangVersion>9.0</LangVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseWPF>true</UseWPF>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PostBuildEvent>mkdir $(TargetDir)lib
 move $(TargetDir)*.dll $(TargetDir)lib</PostBuildEvent>
     <PostBuildEvent>mkdir $(TargetDir)lib

--- a/FFXIV_TexTools/Helpers/ViewportCanvasRenderer.cs
+++ b/FFXIV_TexTools/Helpers/ViewportCanvasRenderer.cs
@@ -1,0 +1,117 @@
+﻿using HelixToolkit.Wpf.SharpDX;
+using FFXIV_TexTools.Configuration;
+using SharpDX.Direct3D11;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace FFXIV_TexTools.Helpers
+{
+    // Transfers textures between DX9 and DX11 (WPF and Helix Toolkit) using the CPU rather than relying on resource sharing APIs
+    class ViewportCanvasRenderer
+    {
+        private Texture2D stagingTexture = null;
+        private ImageBrush canvasBrush = null;
+        private WriteableBitmap canvasBitmap = null;
+
+        public ViewportCanvasRenderer(Viewport3DX viewport3DX, Canvas alternateViewportCanvas)
+        {
+            viewport3DX.OnRendered += Viewport3DX_OnRendered;
+            canvasBrush = new ImageBrush();
+            alternateViewportCanvas.Visibility = Visibility.Visible;
+            alternateViewportCanvas.Background = canvasBrush;
+        }
+
+        private PixelFormat? DXGIFormatToPixelFormat(SharpDX.DXGI.Format dxgiFormat)
+        {
+            switch (dxgiFormat)
+            {
+                case SharpDX.DXGI.Format.B8G8R8A8_UNorm:
+                case SharpDX.DXGI.Format.B8G8R8A8_Typeless:
+                case SharpDX.DXGI.Format.B8G8R8A8_UNorm_SRgb:
+                    return PixelFormats.Bgra32;
+
+                case SharpDX.DXGI.Format.B8G8R8X8_UNorm:
+                case SharpDX.DXGI.Format.B8G8R8X8_Typeless:
+                case SharpDX.DXGI.Format.B8G8R8X8_UNorm_SRgb:
+                    return PixelFormats.Bgr32;
+
+                case SharpDX.DXGI.Format.B5G6R5_UNorm:
+                    return PixelFormats.Bgr565;
+
+                case SharpDX.DXGI.Format.B5G5R5A1_UNorm:
+                    return PixelFormats.Bgr555;
+
+                case SharpDX.DXGI.Format.R8G8B8A8_Typeless:
+                case SharpDX.DXGI.Format.R8G8B8A8_UInt:
+                case SharpDX.DXGI.Format.R8G8B8A8_UNorm:
+                case SharpDX.DXGI.Format.R8G8B8A8_UNorm_SRgb:
+                case SharpDX.DXGI.Format.R8G8B8A8_SInt:
+                case SharpDX.DXGI.Format.R8G8B8A8_SNorm:
+                    return PixelFormats.Rgb24;
+
+                case SharpDX.DXGI.Format.R16G16B16A16_Typeless:
+                case SharpDX.DXGI.Format.R16G16B16A16_UNorm:
+                case SharpDX.DXGI.Format.R16G16B16A16_UInt:
+                case SharpDX.DXGI.Format.R16G16B16A16_SNorm:
+                case SharpDX.DXGI.Format.R16G16B16A16_SInt:
+                    return PixelFormats.Rgba64;
+
+                case SharpDX.DXGI.Format.R32G32B32A32_Float:
+                    return PixelFormats.Rgb128Float;
+
+                default:
+                    return null;
+            }
+        }
+
+        private void Viewport3DX_OnRendered(object sender, System.EventArgs e)
+        {
+            var renderHost = (IRenderHost)sender;
+
+            var deviceContext = renderHost.EffectsManager.Device.ImmediateContext;
+            var backbuffer = renderHost.RenderBuffer.BackBuffer;
+            var backbufferTexture = backbuffer.Resource as Texture2D;
+            var bbDesc = backbufferTexture.Description;
+            if (stagingTexture == null || bbDesc.Width != stagingTexture.Description.Width || bbDesc.Height != stagingTexture.Description.Height)
+            {
+                if (stagingTexture != null)
+                    stagingTexture.Dispose();
+                var desc = bbDesc;
+                var targetFormat = DXGIFormatToPixelFormat(bbDesc.Format);
+                desc.BindFlags = BindFlags.None;
+                desc.CpuAccessFlags = CpuAccessFlags.Read;
+                desc.Usage = ResourceUsage.Staging;
+                stagingTexture = new Texture2D(deviceContext.Device, desc);
+                canvasBitmap = new WriteableBitmap(bbDesc.Width, bbDesc.Height, 96.0, 96.0, targetFormat ?? PixelFormats.Bgr32, null);
+                canvasBrush.ImageSource = canvasBitmap;
+            }
+
+            deviceContext.CopyResource(backbufferTexture, stagingTexture);
+
+            SharpDX.DataStream dataStream;
+            var dataBox = deviceContext.MapSubresource(stagingTexture, 0, 0, MapMode.Read, MapFlags.None, out dataStream);
+            canvasBitmap.Lock();
+            try
+            {
+                for (int row = 0; row < bbDesc.Height; ++row)
+                {
+                    unsafe
+                    {
+                        byte* src = (byte*)(dataBox.DataPointer + row * dataBox.RowPitch);
+                        byte* dest = (byte*)(canvasBitmap.BackBuffer + row * canvasBitmap.BackBufferStride);
+                        System.Buffer.MemoryCopy(src, dest, canvasBitmap.BackBufferStride, dataBox.RowPitch);
+                    }
+                }
+
+                canvasBitmap.AddDirtyRect(new Int32Rect(0, 0, bbDesc.Width, bbDesc.Height));
+            }
+            finally
+            {
+                canvasBitmap.Unlock();
+                deviceContext.UnmapSubresource(stagingTexture, 0);
+            }
+        }
+    }
+}

--- a/FFXIV_TexTools/Views/Controls/ColorsetEditorControl.xaml
+++ b/FFXIV_TexTools/Views/Controls/ColorsetEditorControl.xaml
@@ -251,6 +251,7 @@
                 <hx:DirectionalLight3D IsRendering="True" Direction="-1, 0, 0" Color="White" />
                 <hx:GroupModel3D ItemsSource="{Binding Models}"/>
             </hx:Viewport3DX>
+            <Canvas Grid.Row="2" Name="AlternateViewportCanvas" Visibility="Hidden" IsHitTestVisible="False"/>
         </Grid>
 
     </Grid>

--- a/FFXIV_TexTools/Views/Controls/ColorsetEditorControl.xaml.cs
+++ b/FFXIV_TexTools/Views/Controls/ColorsetEditorControl.xaml.cs
@@ -75,10 +75,15 @@ namespace FFXIV_TexTools.Controls
 
         private List<CheckBox> DyeBoxes = new List<CheckBox>();
 
+        private Helpers.ViewportCanvasRenderer canvasRenderer = null;
+
         public ColorsetEditorControl()
         {
             this.DataContext = _vm = new ColorsetEditorViewModel(this);
             InitializeComponent();
+
+            if (Configuration.EnvironmentConfiguration.TT_Unshared_Rendering)
+                canvasRenderer = new Helpers.ViewportCanvasRenderer(ColorsetRowViewport, AlternateViewportCanvas);
 
             for (int i = 0; i < _rowCount; i++)
             {

--- a/FFXIV_TexTools/Views/Models/FullModelView.xaml
+++ b/FFXIV_TexTools/Views/Models/FullModelView.xaml
@@ -74,6 +74,7 @@
                     <hx:Element3DPresenter Content="{Binding ModelGroup}"/>
                     <hx:PostEffectMeshXRayGrid x:Name="xrayGridEffect" EffectName="xrayGrid" />
                 </hx:Viewport3DX>
+                <Canvas Name="AlternateViewportCanvas" Visibility="Hidden" IsHitTestVisible="False"/>
                 <Label VerticalAlignment="Bottom" HorizontalAlignment="Center" Content="{Binding ModelStatusLabel}" Foreground="#FF151515" FontSize="18"/>
             </Grid>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="5">

--- a/FFXIV_TexTools/Views/Models/FullModelView.xaml.cs
+++ b/FFXIV_TexTools/Views/Models/FullModelView.xaml.cs
@@ -46,9 +46,14 @@ namespace FFXIV_TexTools.Views.Models
 
         public static FullModelView Instance => lazy.Value;
 
+        private Helpers.ViewportCanvasRenderer canvasRenderer = null;
+
         private FullModelView()
         {
             InitializeComponent();
+
+            if (Configuration.EnvironmentConfiguration.TT_Unshared_Rendering)
+                canvasRenderer = new Helpers.ViewportCanvasRenderer(viewport3DX, AlternateViewportCanvas);
 
             _gameDirectory = new DirectoryInfo(Settings.Default.FFXIV_Directory);
             _fmvm = new FullModelViewModel(this);

--- a/FFXIV_TexTools/Views/Models/ModelView.xaml
+++ b/FFXIV_TexTools/Views/Models/ModelView.xaml
@@ -77,6 +77,7 @@
                     Color="White" />
                     <hx:GroupModel3D ItemsSource="{Binding Models}"/>
                 </hx:Viewport3DX>
+                <Canvas Name="AlternateViewportCanvas" Visibility="Hidden" IsHitTestVisible="False"/>
                 <Label x:Name="ViewportDisclaimer" VerticalAlignment="Top" HorizontalAlignment="Center" Content="{Binding Source={x:Static resx:UIStrings.Viewport_Disclaimer}}" Foreground="#FF151515" FontSize="10"/>
                 <Label VerticalAlignment="Bottom" HorizontalAlignment="Center" Content="{Binding ModelStatusLabel}" Foreground="#FF151515" FontSize="18"/>
             </Grid>

--- a/FFXIV_TexTools/Views/Models/ModelView.xaml.cs
+++ b/FFXIV_TexTools/Views/Models/ModelView.xaml.cs
@@ -25,9 +25,14 @@ namespace FFXIV_TexTools.Views
     /// </summary>
     public partial class ModelView : UserControl
     {
+        private Helpers.ViewportCanvasRenderer canvasRenderer = null;
+
         public ModelView()
         {
             InitializeComponent();
+
+            if (Configuration.EnvironmentConfiguration.TT_Unshared_Rendering)
+                canvasRenderer = new Helpers.ViewportCanvasRenderer(viewport3DX, AlternateViewportCanvas);
 
             this.DataContext = new ModelViewModel(this);
         }


### PR DESCRIPTION
This adds two environment variables to help TexTools function on Linux:

`TT_UNSHARED_RENDERING=true` - Defaults to true if WINE is detected, otherwise false.
Uses an alternate method to display model previews, since DXVK seems to fail at DX9/DX11 shared textures for some reason.

`TT_SOFTWARE_RENDERING=true` - Defaults to false.
Disables WPF hardware acceleration, which used to cause issues with earlier versions of DXVK, and might still be useful.


There's a single, very small merge conflict with the develop branch.