### PR TITLE
Disable RLE for TGA exports

### DIFF
--- a/FFXIV_TexTools/Views/FileControls/TextureFileControl.xaml.cs
+++ b/FFXIV_TexTools/Views/FileControls/TextureFileControl.xaml.cs
@@ -236,6 +236,7 @@ namespace FFXIV_TexTools.Views.Controls
             } else {
                 encoder = new TgaEncoder()
                 {
+                    Compression = TgaCompression.None,
                     BitsPerPixel = TgaBitsPerPixel.Pixel32,
                 };
             };


### PR DESCRIPTION
RLE encoding in ImageSharp 2.x branch is entirely broken and produces files bigger than uncompressed.

Reference to where ImageSharp fixed the issue in the 3.x branch only: https://github.com/SixLabors/ImageSharp/commit/5fff1e424154b794170d937905e84471e0c04710