### PR TITLE
Fix Edit Model window crash for Chinese language

### DIFF
--- a/FFXIV_TexTools/Localizations/Localization.cs
+++ b/FFXIV_TexTools/Localizations/Localization.cs
@@ -131,6 +131,10 @@ namespace FFXIV_TexTools.Resources
             var list = new List<(PropertyInfo PropertyInfo, Object Target)>();
             foreach (var elm in elmList.Keys)
             {
+                //Auto-translating the contents of a ComboBox is probably always a mistake, because the item list is not auto-translated
+                if (elm is ComboBox)
+                    continue;
+
                 //GetStringPropertyInfos(elmList, list, elm);
                 var info= GetStringPropertyInfo(elm.GetType());
                 if (info == null)

--- a/FFXIV_TexTools/ViewModels/ImportModelEditViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ImportModelEditViewModel.cs
@@ -460,6 +460,7 @@ namespace FFXIV_TexTools.ViewModels
         }
         private void ModelTypeComboBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
+            if (_view.ModelTypeComboBox.SelectedValue == null) return;
             var val = (EMeshType)_view.ModelTypeComboBox.SelectedValue;
             var m = GetGroup();
             m.MeshType = val;


### PR DESCRIPTION
Fixes #324, caused by auto-translation code trying to change a drop-down selection to a value that doesn't exist.