### PR TITLE
Add traditional chinese (TC) language option

### DIFF
--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -333,7 +333,14 @@ namespace FFXIV_TexTools
             // Validate settings and perform first-time-setup if needed.
             OnboardingWindow.OnboardAndInitialize();
 
-            var ci = new CultureInfo(Properties.Settings.Default.Application_Language)
+            var cultureName = Properties.Settings.Default.Application_Language;
+
+            if (cultureName == "zh")
+                cultureName = "zh-Hans";
+            else if (cultureName == "tc")
+                cultureName = "zh-Hant";
+
+            var ci = new CultureInfo(cultureName)
             {
                 NumberFormat = { NumberDecimalSeparator = "." }
             };
@@ -363,7 +370,7 @@ namespace FFXIV_TexTools
 
             try
             {
-                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "zh")
+                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "zh-Hans")
                 {
                     this.ChinaDiscordButton.Visibility = Visibility.Visible;
                 }

--- a/FFXIV_TexTools/Views/Item/ItemViewControl.xaml.cs
+++ b/FFXIV_TexTools/Views/Item/ItemViewControl.xaml.cs
@@ -1201,6 +1201,11 @@ namespace FFXIV_TexTools.Views.Item
             }
 
             var userRace = XivRaces.GetXivRaceFromDisplayName(Settings.Default.Default_Race_Selection);
+            if (userRace == default)
+            {
+                // Default race setting not valid
+                return null;
+            }
             return GetRacialModel(userRace);
         }
 

--- a/FFXIV_TexTools/Views/LanguageOptionsView.xaml
+++ b/FFXIV_TexTools/Views/LanguageOptionsView.xaml
@@ -23,5 +23,6 @@
         <Button x:Name="FrenchBtn" Content="Français (French)" Margin="10" Click="FrenchBtn_Click"/>
         <Button x:Name="KoreanBtn" Content="한국어 (Korean)" Margin="10" Click="KoreanBtn_Click"/>
         <Button x:Name="ChineseBtn" Content="汉语 (Chinese)" Margin="10" Click="ChineseBtn_Click"/>
+        <Button x:Name="TraditionalChineseBtn" Content="正體字 (Traditional Chinese)" Margin="10" Click="TraditionalChineseBtn_Click"/>
     </StackPanel>
 </UserControl>

--- a/FFXIV_TexTools/Views/LanguageOptionsView.xaml.cs
+++ b/FFXIV_TexTools/Views/LanguageOptionsView.xaml.cs
@@ -75,5 +75,10 @@ namespace FFXIV_TexTools.Views
         {
             UpdateLanguage("zh", "TexTools重新启动以应用更改。");
         }
+
+        private void TraditionalChineseBtn_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            UpdateLanguage("tc", "TexTools重新啓動以應用更改。");
+        }
     }
 }

--- a/FFXIV_TexTools/Views/LanguageSelectView.xaml
+++ b/FFXIV_TexTools/Views/LanguageSelectView.xaml
@@ -16,5 +16,6 @@
         <Button x:Name="FrenchBtn" Content="Français (French)" Margin="10" Click="FrenchBtn_Click"/>
         <Button x:Name="KoreanBtn" Content="한국어 (Korean)" Margin="10" Click="KoreanBtn_Click"/>
         <Button x:Name="ChineseBtn" Content="汉语 (Chinese)" Margin="10" Click="ChineseBtn_Click"/>
+        <Button x:Name="TraditionalChineseBtn" Content="正體字 (Traditional Chinese)" Margin="10" Click="TraditionalChineseBtn_Click"/>
     </StackPanel>
 </mah:MetroWindow>

--- a/FFXIV_TexTools/Views/LanguageSelectView.xaml.cs
+++ b/FFXIV_TexTools/Views/LanguageSelectView.xaml.cs
@@ -65,5 +65,11 @@ namespace FFXIV_TexTools.Views
             LanguageCode = "zh";
             Close();
         }
+
+        private void TraditionalChineseBtn_Click(object sender, RoutedEventArgs e)
+        {
+            LanguageCode = "tc";
+            Close();
+        }
     }
 }

--- a/FFXIV_TexTools/Views/OnboardingWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/OnboardingWindow.xaml.cs
@@ -46,6 +46,7 @@ namespace FFXIV_TexTools.Views
             new KeyValuePair<string, string>("Français (French)", "fr"),
             new KeyValuePair<string, string>("한국어 (Korean)", "ko"),
             new KeyValuePair<string, string>("汉语 (Chinese)", "zh"),
+            new KeyValuePair<string, string>("正體字 (Traditional Chinese)", "tc"),
         };
 
         public static ObservableCollection<KeyValuePair<string, string>> ModelingToolsList { get; set; } = new ObservableCollection<KeyValuePair<string, string>>()


### PR DESCRIPTION
This adds Traditional Chinese to the language selection. Does not add any translated text.

Because of the naming of the .resx files, the simplified chinese translation ends up being used instead of English, due to the fallback priority:

* Fallback priority: `UIStrings.zh-Hant.resx -> UIStrings.zh.resx -> UIStrings.resx`

To implement the Traditional Chinese language translation, create resx files with the `.zh-Hant.resx` suffix.

If you want Traditional Chinese to fall back to English instead of Simplified Chinese, rename the existing `zh` files to `zh-Hans`, so they become independent, e.g.:

* `UIStrings.zh-Hans.resx`
* `UIStrings.zh-Hant.resx`

Depends on xivModdingFramework pull request: https://github.com/TexTools/xivModdingFramework/pull/99