### PR TITLE
Penumbra attach redraw modes

### DIFF
--- a/FFXIV_TexTools/App.config
+++ b/FFXIV_TexTools/App.config
@@ -162,6 +162,9 @@
           <setting name="UseAutoHeels" serializeAs="String">
               <value>True</value>
           </setting>
+          <setting name="PenumbraRedrawMode" serializeAs="String">
+              <value>RedrawAll</value>
+          </setting>
       </FFXIV_TexTools.Properties.Settings>
   </userSettings>
   <runtime>

--- a/FFXIV_TexTools/Properties/Settings.Designer.cs
+++ b/FFXIV_TexTools/Properties/Settings.Designer.cs
@@ -622,5 +622,17 @@ namespace FFXIV_TexTools.Properties {
                 this["UseAutoHeels"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("RedrawAll")]
+        public string PenumbraRedrawMode {
+            get {
+                return ((string)(this["PenumbraRedrawMode"]));
+            }
+            set {
+                this["PenumbraRedrawMode"] = value;
+            }
+        }
     }
 }

--- a/FFXIV_TexTools/Properties/Settings.settings
+++ b/FFXIV_TexTools/Properties/Settings.settings
@@ -152,5 +152,8 @@
     <Setting Name="UseAutoHeels" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="PenumbraRedrawMode" Type="System.String" Scope="User">
+      <Value Profile="(Default)">RedrawAll</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FFXIV_TexTools/ViewModels/CustomizeViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/CustomizeViewModel.cs
@@ -69,6 +69,14 @@ namespace FFXIV_TexTools.ViewModels
             new KeyValuePair<string, string>("PMP", "pmp"),
             new KeyValuePair<string, string>("TTMP2", "ttmp2"),
         };
+
+        public ObservableCollection<KeyValuePair<string, string>> PenumbraRedrawModes { get; set; } = new ObservableCollection<KeyValuePair<string, string>>()
+        {
+            new KeyValuePair<string, string>("Redraw All", "RedrawAll"),
+            new KeyValuePair<string, string>("Redraw Self", "RedrawSelf"),
+            new KeyValuePair<string, string>("Don't Redraw", "NoRedraw"),
+        };
+
         public CustomizeViewModel(CustomizeSettingsView view)
         {
             _view = view;
@@ -566,6 +574,28 @@ namespace FFXIV_TexTools.ViewModels
             }
         }
 
+        public string SelectedPenumbraRedrawMode
+        {
+            get
+            {
+                try
+                {
+                    return Settings.Default.PenumbraRedrawMode;
+                }
+                catch
+                {
+                    return default(FrameworkSettings.EPenumbraRedrawMode).ToString();
+                }
+            }
+            set
+            {
+                if (SelectedPenumbraRedrawMode != value)
+                {
+                    SetPenumbraRedrawMode(value);
+                }
+            }
+        }
+
         public bool ExportTextureAsDDS
         {
             get => Settings.Default.ExportTexDDS;
@@ -905,6 +935,16 @@ namespace FFXIV_TexTools.ViewModels
         {
             Settings.Default.Default_Race_Selection = selectedRace;
             Settings.Default.Save();
+            NotifyPropertyChanged(nameof(SelectedDefaultRace));
+        }
+
+        private void SetPenumbraRedrawMode(string selectedMode)
+        {
+            Settings.Default.PenumbraRedrawMode = selectedMode;
+            Settings.Default.Save();
+            if (Enum.TryParse<FrameworkSettings.EPenumbraRedrawMode>(selectedMode, out var mode))
+                XivCache.FrameworkSettings.PenumbraRedrawMode = mode;
+            NotifyPropertyChanged(nameof(SelectedPenumbraRedrawMode));
         }
 
         /// <summary>

--- a/FFXIV_TexTools/Views/CustomizeSettingsView.xaml
+++ b/FFXIV_TexTools/Views/CustomizeSettingsView.xaml
@@ -59,6 +59,7 @@
         <ToolTip x:Key="ModpackAuthorTooltip">Sets the default Author Name when creating modpacks.</ToolTip>
         <ToolTip x:Key="ModpackUrlTooltip">Sets the default Author Url/Website when creating modpacks.</ToolTip>
         <ToolTip x:Key="DefaultRaceTooltip">Sets the default race the UI will attempt to navigate to when selecting an item for the first time.</ToolTip>
+        <ToolTip x:Key="PenumbraRedrawModeTooltip">Automatic redraw mode when making mod file changes using Penumbra Attach.</ToolTip>
 
         <ToolTip x:Key="SkinRaceTooltip">
             <TextBlock>
@@ -113,6 +114,7 @@
                         <RowDefinition Height="30"/>
                         <RowDefinition Height="30"/>
                         <RowDefinition Height="30"/>
+                        <RowDefinition Height="30"/>
                     </Grid.RowDefinitions>
 
                     <Label Grid.Column="0" Grid.Row="0"  Margin="5,0" Content="Default Modack Author" VerticalAlignment="Center" HorizontalContentAlignment="Right" VerticalContentAlignment="Center"  ToolTip="{StaticResource ModpackAuthorTooltip}"></Label>
@@ -131,6 +133,9 @@
 
                     <Label Grid.Column="0" Grid.Row="2" Margin="5,0" Content="Default Race" VerticalAlignment="Center" HorizontalContentAlignment="Right" VerticalContentAlignment="Center"  ToolTip="{StaticResource DefaultRaceTooltip}"></Label>
                     <ComboBox x:Name="DefaultRacesBox" Grid.Column="1" Grid.Row="2"  VerticalAlignment="Center" ItemsSource="{Binding DefaultRaces}" SelectedItem="{Binding SelectedDefaultRace}" Margin="5,0"  ToolTip="{StaticResource DefaultRaceTooltip}"/>
+
+                    <Label Grid.Column="0" Grid.Row="3" Margin="5,0" Content="Penumbra Redraw Mode" VerticalAlignment="Center" HorizontalContentAlignment="Right" VerticalContentAlignment="Center"  ToolTip="{StaticResource PenumbraRedrawModeTooltip}"></Label>
+                    <ComboBox x:Name="PenumbraRedrawModesBox" Grid.Column="1" Grid.Row="3"  VerticalAlignment="Center" ItemsSource="{Binding PenumbraRedrawModes}" SelectedValue="{Binding SelectedPenumbraRedrawMode}" SelectedValuePath="Value" DisplayMemberPath="Key" Margin="5,0" ToolTip="{StaticResource PenumbraRedrawModeTooltip}"/>
 
                 </Grid>
             </GroupBox>

--- a/FFXIV_TexTools/Views/OnboardingWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/OnboardingWindow.xaml.cs
@@ -224,6 +224,9 @@ namespace FFXIV_TexTools.Views
             }
             XivCache.FrameworkSettings.DefaultTextureFormat = Settings.Default.CompressEndwalkerUpgradeTextures ? xivModdingFramework.Textures.Enums.XivTexFormat.BC7 : xivModdingFramework.Textures.Enums.XivTexFormat.A8R8G8B8;
 
+            if (Enum.TryParse<FrameworkSettings.EPenumbraRedrawMode>(Settings.Default.PenumbraRedrawMode, out var mode))
+                XivCache.FrameworkSettings.PenumbraRedrawMode = mode;
+
             UpdateConsoleConfig();
             Properties.Settings.Default.SettingsSaving += (object sender, System.ComponentModel.CancelEventArgs e) => {
                 UpdateConsoleConfig();

--- a/FFXIV_TexTools/Views/Transactions/TransactionStatusWindow.xaml
+++ b/FFXIV_TexTools/Views/Transactions/TransactionStatusWindow.xaml
@@ -52,7 +52,13 @@
                 <Button x:Name="PenumbraRestore" Content="Restore Mod Backup" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,155,0" Width="150" Click="RestorePenumbraBackup_Click" IsEnabled="{Binding Path=TxActionEnabled}"></Button>
                 <Button Content="Reset Selected File(s)" HorizontalAlignment="Right" VerticalAlignment="Center" Click="ResetFiles_Click" Width="150"></Button>
                 <Border Grid.Row="1" BorderBrush="{DynamicResource NormalBorderBrush}" BorderThickness="1">
-                    <ListBox x:Name="FileListBox" Grid.Row="0" ItemsSource="{Binding Path=FileListSource}" SelectionMode="Extended"></ListBox>
+                    <ListBox x:Name="FileListBox" Grid.Row="0" ItemsSource="{Binding Path=FileListSource}" SelectionMode="Extended">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <EventSetter Event="MouseDoubleClick" Handler="FileListBoxItem_DoubleClick" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                    </ListBox>
                 </Border>
             </Grid>
 

--- a/FFXIV_TexTools/Views/Transactions/TransactionStatusWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/Transactions/TransactionStatusWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using FFXIV_TexTools.Helpers;
 using FFXIV_TexTools.Properties;
 using FFXIV_TexTools.Resources;
+using FFXIV_TexTools.Views.Controls;
 using FFXIV_TexTools.Views.Projects;
 using System;
 using System.Collections.Generic;
@@ -665,7 +666,23 @@ namespace FFXIV_TexTools.Views.Transactions
             }
         }
 
-        static BetterFolderBrowser PenumbraAttachDialog = new BetterFolderBrowser();
+        private async void FileListBoxItem_DoubleClick(object sender, RoutedEventArgs e)
+        {
+            if (sender is ListBoxItem item && item.DataContext is string filePath)
+            {
+                try
+                {
+                    await SimpleFileViewWindow.OpenFile(filePath);
+                }
+                catch (Exception Ex)
+                {
+                    Trace.WriteLine(Ex);
+                }
+            }
+        }
+
+        static FolderSelectDialog PenumbraAttachDialog = new FolderSelectDialog();
+
         private async void AttachPenumbra_Click(object sender, RoutedEventArgs e)
         {
 


### PR DESCRIPTION
Implements two new redraw modes:
* Redraw All (only kind that previously existed)
* Redraw Self
* Don't Redraw

Depends on: https://github.com/TexTools/xivModdingFramework/pull/101