### PR TITLE
Remove BetterFolderBrowser

### DIFF
--- a/FFXIV_TexTools/FFXIV_TexTools.csproj
+++ b/FFXIV_TexTools/FFXIV_TexTools.csproj
@@ -67,7 +67,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autoupdater.NET.Official" Version="1.9.1" />
-    <PackageReference Include="BetterFolderBrowser" Version="1.2.0" />
     <PackageReference Include="ControlzEx" Version="3.0.2.4">
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>

--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -57,7 +57,6 @@ using System.Windows.Forms;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Threading;
-using WK.Libraries.BetterFolderBrowserNS;
 using xivModdingFramework.Cache;
 using xivModdingFramework.Exd.FileTypes;
 using xivModdingFramework.General.Enums;
@@ -1236,21 +1235,21 @@ namespace FFXIV_TexTools
             }
 
 
-            var ofd = new BetterFolderBrowser {
+            var ofd = new FolderSelectDialog {
                 Title = "Import FFXIV Folder Tree"
             };
 
-            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            if (!ofd.ShowDialog())
                 return;
 
             try
             {
                 // See if we can get the information in simple mode.
-                var modPackFiles = await TTMP.ModPackToSimpleFileList(ofd.SelectedPath, false, MainWindow.UserTransaction);
+                var modPackFiles = await TTMP.ModPackToSimpleFileList(ofd.FileName, false, MainWindow.UserTransaction);
 
                 if (modPackFiles != null)
                 {
-                    FileListImporter.ShowModpackImport(ofd.SelectedPath, modPackFiles.Keys.ToList(), this);
+                    FileListImporter.ShowModpackImport(ofd.FileName, modPackFiles.Keys.ToList(), this);
                     return;
                 }
             } catch(Exception ex)

--- a/FFXIV_TexTools/ViewModels/CustomizeViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/CustomizeViewModel.cs
@@ -29,7 +29,6 @@ using System.IO;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
-using WK.Libraries.BetterFolderBrowserNS;
 using xivModdingFramework.Cache;
 using xivModdingFramework.General.Enums;
 using xivModdingFramework.Helpers;
@@ -660,7 +659,7 @@ namespace FFXIV_TexTools.ViewModels
         /// </summary>
         private void FFXIVSelectDir(object obj)
         {
-            var ofd = new BetterFolderBrowser()
+            var ofd = new FolderSelectDialog()
             {
                 Title = "Select FFXIV Folder",
             };
@@ -668,29 +667,29 @@ namespace FFXIV_TexTools.ViewModels
             var previous = Settings.Default.FFXIV_Directory;
             if (!string.IsNullOrWhiteSpace(Settings.Default.FFXIV_Directory))
             {
-                ofd.RootFolder = Settings.Default.FFXIV_Directory;
+                ofd.InitialDirectory = Settings.Default.FFXIV_Directory;
             }
             else if (!string.IsNullOrWhiteSpace(OnboardingWindow.GetDefaultInstallDirectory()))
             {
-                ofd.RootFolder = OnboardingWindow.GetDefaultInstallDirectory();
+                ofd.InitialDirectory = OnboardingWindow.GetDefaultInstallDirectory();
             }
 
 
-            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            if (!ofd.ShowDialog())
             {
                 return;
             }
 
-            var path = OnboardingWindow.ResolveFFXIVFolder(ofd.SelectedFolder);
+            var path = OnboardingWindow.ResolveFFXIVFolder(ofd.FileName);
 
             while (!OnboardingWindow.IsGameDirectoryValid(path))
             {
                 FlexibleMessageBox.Show("Invalid FFXIV Install", "Please select a valid FFXIV install folder.", MessageBoxButtons.OK, MessageBoxIcon.Question);
-                if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+                if (!ofd.ShowDialog())
                 {
                     return;
                 }
-                path = OnboardingWindow.ResolveFFXIVFolder(ofd.SelectedFolder);
+                path = OnboardingWindow.ResolveFFXIVFolder(ofd.FileName);
             }
 
             Settings.Default.FFXIV_Directory = path;

--- a/FFXIV_TexTools/Views/FileControls/ModelFileControl.xaml.cs
+++ b/FFXIV_TexTools/Views/FileControls/ModelFileControl.xaml.cs
@@ -45,8 +45,8 @@ using SharpDX;
 using ControlzEx.Standard;
 using System.Windows.Media.Media3D;
 using System.Runtime.CompilerServices;
-using WK.Libraries.BetterFolderBrowserNS;
 using System.Text.RegularExpressions;
+using FolderSelect;
 
 namespace FFXIV_TexTools.Views.Controls
 {
@@ -873,18 +873,18 @@ namespace FFXIV_TexTools.Views.Controls
 
         private async void ExportTextures_Click(object sender, RoutedEventArgs e)
         {
-            var bf = new BetterFolderBrowser();
-            bf.Title = "Select Export Folder";
+            var fsd = new FolderSelectDialog();
+            fsd.Title = "Select Export Folder";
 
             var path = Path.GetFullPath(Path.Combine(GetDefaultSaveDirectory() + "../RawTextures/"));
             Directory.CreateDirectory(path);
-            bf.RootFolder = path;
+            fsd.InitialDirectory = path;
 
-            if (bf.ShowDialog() != DialogResult.OK)
+            if (!fsd.ShowDialog())
             {
                 return;
             }
-            path = bf.SelectedFolder;
+            path = fsd.FileName;
 
 
             try
@@ -898,7 +898,7 @@ namespace FFXIV_TexTools.Views.Controls
                         set = await Imc.GetMaterialSetId(im, false, MainWindow.DefaultTransaction);
                     }
                     Model.Source = InternalFilePath;
-                    await Mdl.ExportAllTextures(Model, bf.SelectedPath, set, MainWindow.DefaultTransaction);
+                    await Mdl.ExportAllTextures(Model, fsd.FileName, set, MainWindow.DefaultTransaction);
                 });
             } catch(Exception ex)
             {
@@ -985,19 +985,19 @@ namespace FFXIV_TexTools.Views.Controls
 
         private async void ExportPbrTextures_Click(object sender, RoutedEventArgs e)
         {
-            var bf = new BetterFolderBrowser();
-            bf.Title = "Select Export Folder";
+            var fsd = new FolderSelectDialog();
+            fsd.Title = "Select Export Folder";
 
             var path = Path.GetFullPath(Path.Combine(GetDefaultSaveDirectory(), "PbrTextures"));
             Directory.CreateDirectory(path);
-            bf.RootFolder = path;
+            fsd.InitialDirectory = path;
 
-            if (bf.ShowDialog() != DialogResult.OK)
+            if (!fsd.ShowDialog())
             {
                 return;
             }
 
-            path = bf.SelectedFolder;
+            path = fsd.FileName;
 
             // Because the export for model expects an actual file path, not a folder path.
             path = Path.GetFullPath(Path.Combine(path, "asdf.fbx"));

--- a/FFXIV_TexTools/Views/OnboardingWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/OnboardingWindow.xaml.cs
@@ -25,7 +25,6 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using WK.Libraries.BetterFolderBrowserNS;
 using xivModdingFramework.Cache;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.Models.DataContainers;
@@ -627,7 +626,7 @@ namespace FFXIV_TexTools.Views
 
         private void SelectGamePath_Click(object sender, RoutedEventArgs e)
         {
-            var ofd = new BetterFolderBrowser()
+            var ofd = new FolderSelectDialog()
             {
                 Title = "Select FFXIV Folder",
             };
@@ -635,29 +634,29 @@ namespace FFXIV_TexTools.Views
             var previous = Settings.Default.FFXIV_Directory;
             if (!string.IsNullOrWhiteSpace(Settings.Default.FFXIV_Directory))
             {
-                ofd.RootFolder = Settings.Default.FFXIV_Directory;
+                ofd.InitialDirectory = Settings.Default.FFXIV_Directory;
             } else if(!string.IsNullOrWhiteSpace(GetDefaultInstallDirectory()))
             {
-                ofd.RootFolder = GetDefaultInstallDirectory();
+                ofd.InitialDirectory = GetDefaultInstallDirectory();
             }
 
             var win = ViewHelpers.GetWin32Window(this);
 
-            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            if (!ofd.ShowDialog())
             {
                 return;
             }
 
-            var path = ResolveFFXIVFolder(ofd.SelectedFolder);
+            var path = ResolveFFXIVFolder(ofd.FileName);
 
             while (!IsGameDirectoryValid(path))
             {
                 FlexibleMessageBox.Show(win, "Invalid FFXIV Install", "Please select a valid FFXIV install folder.", MessageBoxButtons.OK, MessageBoxIcon.Question);
-                if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+                if (!ofd.ShowDialog())
                 {
                     return;
                 }
-                path = ResolveFFXIVFolder(ofd.SelectedFolder);
+                path = ResolveFFXIVFolder(ofd.FileName);
             }
 
             ViewModel.FFXIV_Directory = path;
@@ -665,56 +664,56 @@ namespace FFXIV_TexTools.Views
 
         private void SelectSavePath_Click(object sender, RoutedEventArgs e)
         {
-            var ofd = new BetterFolderBrowser()
+            var ofd = new FolderSelectDialog()
             {
                 Title = "Select Default Save Folder",
             };
 
             Directory.CreateDirectory(Settings.Default.Save_Directory);
-            ofd.RootFolder = Path.GetFullPath(Settings.Default.Save_Directory);
+            ofd.InitialDirectory = Path.GetFullPath(Settings.Default.Save_Directory);
 
-            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            if (!ofd.ShowDialog())
             {
                 return;
             }
 
-            ViewModel.Save_Directory = ofd.SelectedFolder;
+            ViewModel.Save_Directory = ofd.FileName;
         }
 
         private void SelectModpackPath_Click(object sender, RoutedEventArgs e)
         {
-            var ofd = new BetterFolderBrowser()
+            var ofd = new FolderSelectDialog()
             {
                 Title = "Select Modpack Folder",
             };
 
             Directory.CreateDirectory(Settings.Default.ModPack_Directory);
-            ofd.RootFolder = Path.GetFullPath(Settings.Default.ModPack_Directory);
+            ofd.InitialDirectory = Path.GetFullPath(Settings.Default.ModPack_Directory);
 
-            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            if (!ofd.ShowDialog())
             {
                 return;
             }
 
-            ViewModel.ModPack_Directory = ofd.SelectedFolder;
+            ViewModel.ModPack_Directory = ofd.FileName;
         }
 
         private void SelectBackupPath_Click(object sender, RoutedEventArgs e)
         {
-            var ofd = new BetterFolderBrowser()
+            var ofd = new FolderSelectDialog()
             {
                 Title = "Select Index Backup Folder",
             };
 
             Directory.CreateDirectory(Settings.Default.Backup_Directory);
-            ofd.RootFolder = Path.GetFullPath(Settings.Default.Backup_Directory);
+            ofd.InitialDirectory = Path.GetFullPath(Settings.Default.Backup_Directory);
 
-            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            if (!ofd.ShowDialog())
             {
                 return;
             }
 
-            ViewModel.Backup_Directory = ofd.SelectedFolder;
+            ViewModel.Backup_Directory = ofd.FileName;
         }
 
         private void UseCase_Changed(object sender, SelectionChangedEventArgs e)

--- a/FFXIV_TexTools/Views/Projects/ProjectWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/Projects/ProjectWindow.xaml.cs
@@ -2,6 +2,7 @@
 using FFXIV_TexTools.Resources;
 using FFXIV_TexTools.Views.Controls;
 using FFXIV_TexTools.Views.Transactions;
+using FolderSelect;
 using MahApps.Metro.Controls.Dialogs;
 using Newtonsoft.Json;
 using System;
@@ -20,7 +21,6 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using WK.Libraries.BetterFolderBrowserNS;
 using xivModdingFramework.Exd.FileTypes;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.Models.Helpers;
@@ -217,14 +217,14 @@ namespace FFXIV_TexTools.Views.Projects
                     return;
                 }
             }
-            var sfd = new BetterFolderBrowser();
-            sfd.RootFolder = PenumbraAPI.GetPenumbraDirectory();
-            if (sfd.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            var sfd = new FolderSelectDialog();
+            sfd.InitialDirectory = PenumbraAPI.GetPenumbraDirectory();
+            if (!sfd.ShowDialog())
             {
                 return;
             }
 
-            var folder = sfd.SelectedPath;
+            var folder = sfd.FileName;
 
             try
             {

--- a/FFXIV_TexTools/Views/Transactions/TransactionStatusWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/Transactions/TransactionStatusWindow.xaml.cs
@@ -2,6 +2,7 @@
 using FFXIV_TexTools.Properties;
 using FFXIV_TexTools.Resources;
 using FFXIV_TexTools.Views.Projects;
+using FolderSelect;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -21,7 +22,6 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using WK.Libraries.BetterFolderBrowserNS;
 using xivModdingFramework.Cache;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.Mods;
@@ -665,7 +665,7 @@ namespace FFXIV_TexTools.Views.Transactions
             }
         }
 
-        static BetterFolderBrowser PenumbraAttachDialog = new BetterFolderBrowser();
+        static FolderSelectDialog PenumbraAttachDialog = new FolderSelectDialog();
         private async void AttachPenumbra_Click(object sender, RoutedEventArgs e)
         {
 
@@ -687,15 +687,14 @@ namespace FFXIV_TexTools.Views.Transactions
 
             PenumbraAttachDialog.Title = "Select Penumbra Mod Folder...";
 
-            PenumbraAttachDialog.RootFolder = PenumbraAPI.GetPenumbraDirectory();
+            PenumbraAttachDialog.InitialDirectory = PenumbraAPI.GetPenumbraDirectory();
 
-            var res = PenumbraAttachDialog.ShowDialog();
-            if (res != System.Windows.Forms.DialogResult.OK)
+            if (!PenumbraAttachDialog.ShowDialog())
             {
                 return;
             }
 
-            var path = Path.GetFullPath(Path.Combine(PenumbraAttachDialog.SelectedPath, "meta.json"));
+            var path = Path.GetFullPath(Path.Combine(PenumbraAttachDialog.FileName, "meta.json"));
             if (!File.Exists(path))
             {
                 ViewHelpers.ShowError("Invalid Penumbra Mod Folder", "The selected folder was not a valid Penumbra mod folder.\nPlease select an individual Penumbra Mod folder.");
@@ -707,7 +706,7 @@ namespace FFXIV_TexTools.Views.Transactions
 
             var backupFolder = Path.Combine(Path.GetTempPath(), "TexTools_Transaction_Backup");
             IOUtil.DeleteTempDirectory(backupFolder);
-            IOUtil.CopyFolder(PenumbraAttachDialog.SelectedPath, backupFolder);
+            IOUtil.CopyFolder(PenumbraAttachDialog.FileName, backupFolder);
 
             var tx = MainWindow.UserTransaction;
             if(tx == null)
@@ -716,14 +715,14 @@ namespace FFXIV_TexTools.Views.Transactions
                 {
                     StorageType = xivModdingFramework.SqPack.FileTypes.EFileStorageType.UncompressedIndividual,
                     Target = ETransactionTarget.PenumbraModFolder,
-                    TargetPath = PenumbraAttachDialog.SelectedPath,
+                    TargetPath = PenumbraAttachDialog.FileName,
                     Unsafe = false
                 };
                 tx = await ModTransaction.BeginTransaction(true, null, settings, true, true);
                 MainWindow.UserTransaction = tx;
             }
 
-             await PenumbraAttachHandler.Attach(PenumbraAttachDialog.SelectedPath, MainWindow.UserTransaction);
+             await PenumbraAttachHandler.Attach(PenumbraAttachDialog.FileName, MainWindow.UserTransaction);
         }
 
         private void Close_Click(object sender, RoutedEventArgs e)

--- a/FFXIV_TexTools/Views/Upgrades/PenumbraLibraryUpgradeWindow.xaml.cs
+++ b/FFXIV_TexTools/Views/Upgrades/PenumbraLibraryUpgradeWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using AutoUpdaterDotNET;
 using FFXIV_TexTools.Models;
+using FolderSelect;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -19,7 +20,6 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using WK.Libraries.BetterFolderBrowserNS;
 using xivModdingFramework.Cache;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.Mods;
@@ -244,27 +244,27 @@ namespace FFXIV_TexTools.Views.Upgrades
 
         private void SelectPenumbraPath_Click(object sender, RoutedEventArgs e)
         {
-            var bfb = new BetterFolderBrowser() { Title = "Select Penumbra Library..." };
-            bfb.RootFolder = PenumbraPath;
-            if(bfb.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            var fsb = new FolderSelectDialog() { Title = "Select Penumbra Library..." };
+            fsb.InitialDirectory = PenumbraPath;
+            if(!fsb.ShowDialog())
             {
                 return;
             }
 
-            PenumbraPath = bfb.SelectedFolder;
+            PenumbraPath = fsb.FileName;
             CheckPaths();
         }
 
         private void SelectDestinationPath_Click(object sender, RoutedEventArgs e)
         {
-            var bfb = new BetterFolderBrowser() { Title = "Select Destination Folder..." };
-            bfb.RootFolder = DestinationPath;
-            if (bfb.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            var fsb = new FolderSelectDialog() { Title = "Select Destination Folder..." };
+            fsb.InitialDirectory = DestinationPath;
+            if (!fsb.ShowDialog())
             {
                 return;
             }
 
-            DestinationPath = bfb.SelectedFolder;
+            DestinationPath = fsb.FileName;
             CheckPaths();
         }
 


### PR DESCRIPTION
The implementation of FolderSelectDialog that already exists in TexTools is identical to what BetterFolderBrowser uses anyway.

Also wraps the code in a try/catch to try and fix a failure (CreateVistaDialog returning null) which prevents TexTools from working on WINE for some people.